### PR TITLE
[round-6]  Failure-Ready Systems

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -13,6 +13,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
+    // openfeign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // querydsl
     implementation("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
@@ -25,6 +32,11 @@ dependencies {
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
+
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+
+
+
 
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -4,10 +4,15 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableFeignClients
+@EnableScheduling
 public class CommerceApiApplication {
 
     @PostConstruct

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
@@ -1,5 +1,7 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
 import com.loopers.domain.product.ProductCommand;
 import com.loopers.domain.stock.StockCommand;
 import com.loopers.domain.usercoupon.UserCouponCommand;
@@ -17,19 +19,49 @@ public class OrderCriteria {
         String userId;
         List<OrderProduct> orderProducts;
         Long couponId;
+        PaymentType paymentType;
+        CardType cardType;
+        String cardNo;
 
-        private Order(String userId, List<OrderProduct> orderProducts, Long couponId) {
+        private Order(String userId, List<OrderProduct> orderProducts, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
             this.userId = userId;
             this.orderProducts = orderProducts;
             this.couponId = couponId;
+            this.paymentType = paymentType;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
         }
 
-        public static Order of(String userId, List<OrderProduct> orderProducts, Long couponId) {
+        public static Order ofCard(String userId, List<OrderProduct> orderProducts, Long couponId, CardType cardType, String cardNo) {
             return Order.builder()
                     .userId(userId)
                     .orderProducts(orderProducts)
                     .couponId(couponId)
+                    .paymentType(PaymentType.CARD)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
                     .build();
+        }
+
+        public static Order ofPoint(String userId, List<OrderProduct> orderProducts, Long couponId) {
+            return Order.builder()
+                    .userId(userId)
+                    .orderProducts(orderProducts)
+                    .couponId(couponId)
+                    .paymentType(PaymentType.POINT)
+                    .build();
+        }
+
+        public static Order of(String userId, List<OrderProduct> orderProducts, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
+            return Order.builder()
+                    .userId(userId)
+                    .orderProducts(orderProducts)
+                    .couponId(couponId)
+                    .paymentType(paymentType)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
+                    .build();
+
         }
 
         public ProductCommand.OrderProducts toProductCommand() {
@@ -88,8 +120,4 @@ public class OrderCriteria {
                     .build();
         }
     }
-
-
-
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentCriteria.java
@@ -1,0 +1,30 @@
+package com.loopers.application.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class PaymentCriteria {
+
+    @Getter
+    @Builder
+    public static class PaymentResult {
+        private String transactionKey;
+        private String orderId;
+        private String cardType;
+        private String cardNo;
+        private Long amount;
+        private String status;
+        private String reason;
+
+        private PaymentResult(String transactionKey, String orderId, String cardType, String cardNo, Long amount, String status, String reason) {
+            this.transactionKey = transactionKey;
+            this.orderId = orderId;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.status = status;
+            this.reason = reason;
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,0 +1,35 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.OrderInfo;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.pg.PgCommonResponse;
+import com.loopers.domain.stock.StockService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final PaymentService paymentService;
+
+    private final OrderService orderService;
+
+    private final StockService stockService;
+
+
+    @Transactional
+    public void processPaymentResult(PaymentCriteria.PaymentResult paymentResult) {
+        if (paymentResult.getStatus().equalsIgnoreCase("SUCCESS")) {
+            paymentService.pay(paymentResult.getOrderId());
+            OrderInfo.OrderProducts orderProducts = orderService.getOrderProducts(paymentResult.getOrderId());
+            stockService.decreaseStock(orderProducts.toStockCommandOrderProducts());
+            orderService.complete(paymentResult.getOrderId());
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/pg/PgCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/pg/PgCriteria.java
@@ -1,0 +1,61 @@
+package com.loopers.application.pg;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.pg.PgCommand;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PgCriteria {
+
+    @Getter
+    @Builder
+    public static class PaymentEvent {
+        private String userId;
+        private Payment payment;
+
+        private PaymentEvent(String userId, Payment payment) {
+            this.userId = userId;
+            this.payment = payment;
+        }
+
+        public static PaymentEvent of(String userId, Payment payment) {
+            return PaymentEvent.builder()
+                    .userId(userId)
+                    .payment(payment)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Payment {
+        private String orderId;
+        private CardType cardType;
+        private String cardNo;
+        private String amount;
+        private String callbackUrl;
+
+        private Payment(String orderId, CardType cardType, String cardNo, String amount, String callbackUrl) {
+            this.orderId = orderId;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.callbackUrl = callbackUrl;
+        }
+
+        public static Payment of(String orderId, CardType cardType, String cardNo, String amount, String callbackUrl) {
+            return Payment.builder()
+                    .orderId(orderId)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
+                    .amount(amount)
+                    .callbackUrl(callbackUrl)
+                    .build();
+        }
+
+        public PgCommand.PaymentRequest toPgCommand() {
+            return PgCommand.PaymentRequest.of(orderId, cardType, cardNo, amount, callbackUrl);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/pg/PgFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/pg/PgFacade.java
@@ -1,0 +1,16 @@
+package com.loopers.application.pg;
+
+
+import com.loopers.domain.pg.PgService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PgFacade {
+    private final PgService pgService;
+
+    public void requestPayment(PgCriteria.PaymentEvent paymentEvent) {
+        pgService.requestPayment(paymentEvent.getUserId(), paymentEvent.getPayment().toPgCommand());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/config/PgFeignClientConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/PgFeignClientConfig.java
@@ -1,0 +1,14 @@
+package com.loopers.config;
+
+import feign.Request;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PgFeignClientConfig {
+
+    @Bean
+    public Request.Options feignOption() {
+        return new Request.Options(1000, 3000);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Getter
@@ -22,6 +23,8 @@ public class Order {
     @Column(name = "order_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String orderNumber;
 
     private String userId;
 
@@ -37,8 +40,9 @@ public class Order {
     private List<OrderProduct> orderProducts = new ArrayList<>();
 
     @Builder
-    private Order(String userId, OrderStatus orderStatus, Long totalPrice, List<OrderProduct> orderProducts) {
+    private Order(String userId, String orderNumber, OrderStatus orderStatus, Long totalPrice, List<OrderProduct> orderProducts) {
         this.userId = userId;
+        this.orderNumber = orderNumber;
         this.orderStatus = orderStatus;
         this.totalPrice = totalPrice;
         this.orderProducts = orderProducts;
@@ -59,6 +63,7 @@ public class Order {
 
         Order order = Order.builder()
                 .userId(userId)
+                .orderNumber(UUID.randomUUID().toString())
                 .orderStatus(OrderStatus.PENDING)
                 .totalPrice(0L) // 임시 값
                 .orderProducts(new ArrayList<>())

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -13,6 +13,7 @@ public class OrderCommand {
         String userId;
         OrderProducts orderProducts;
 
+
         private Order(String userId, OrderProducts orderProducts) {
             this.userId = userId;
             this.orderProducts = orderProducts;
@@ -29,17 +30,17 @@ public class OrderCommand {
     @Getter
     @Builder
     public static class OrderStatus {
-        private Long orderId;
+        private String orderNumber;
         private String status;
 
-        private OrderStatus(Long orderId, String status) {
-            this.orderId = orderId;
+        private OrderStatus(String orderNumber, String status) {
+            this.orderNumber = orderNumber;
             this.status = status;
         }
 
-        public static OrderCommand.OrderStatus of(Long orderId, String status) {
+        public static OrderCommand.OrderStatus of(String orderNumber, String status) {
             return OrderStatus.builder()
-                    .orderId(orderId)
+                    .orderNumber(orderNumber)
                     .status(status)
                     .build();
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.order;
 
+import com.loopers.domain.stock.StockCommand;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -84,36 +85,44 @@ public class OrderInfo {
     @Getter
     @Builder
     public static class OrderProducts {
-        private List<OrderProduct> orderProducts;
+        private List<OrderProductDto> orderProductDtos;
 
-        private OrderProducts(List<OrderProduct> orderProducts) {
-            this.orderProducts = orderProducts;
+        private OrderProducts(List<OrderProductDto> orderProductDtos) {
+            this.orderProductDtos = orderProductDtos;
         }
 
-        public static OrderProducts of(List<OrderProduct> orderProducts) {
+        public static OrderProducts of(List<OrderProductDto> orderProductDtos) {
             return OrderProducts.builder()
-                    .orderProducts(orderProducts)
+                    .orderProductDtos(orderProductDtos)
                     .build();
+        }
+
+        public static OrderProducts from(List<OrderProduct> orderProductDtos) {
+            return OrderProducts.of(orderProductDtos.stream().map(o -> OrderProductDto.of(o.getProductId(), o.getQuantity(), o.getPrice())).toList());
+        }
+
+        public StockCommand.OrderProducts toStockCommandOrderProducts() {
+            return StockCommand.OrderProducts.of(this.orderProductDtos.stream().map(o -> StockCommand.OrderProduct.of(o.getProductId(), o.getQuantity())).toList());
         }
     }
 
 
     @Getter
     @Builder
-    public static class OrderProduct {
+    public static class OrderProductDto {
         private Long productId;
         private Long quantity;
         private Long price;
 
 
-        private OrderProduct(Long productId, Long quantity, Long price) {
+        private OrderProductDto(Long productId, Long quantity, Long price) {
             this.productId = productId;
             this.quantity = quantity;
             this.price = price;
         }
 
-        public static OrderProduct of(Long productId, Long quantity, Long price) {
-            return OrderProduct.builder()
+        public static OrderProductDto of(Long productId, Long quantity, Long price) {
+            return OrderProductDto.builder()
                     .productId(productId)
                     .quantity(quantity)
                     .price(price)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -8,8 +8,9 @@ public interface OrderRepository {
 
     Order findById(Long orderId);
 
-    List<OrderProduct> findOrderProductsByOrderId(Long orderId);
+    Order findByOrderNumber(String orderNumber);
 
+    List<OrderProduct> findOrderProductsByOrderId(Long orderId);
 
     List<Order> findByUserId(String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -25,9 +25,9 @@ public class OrderService {
         return orderRepository.save(order);
     }
 
-    public void pay(OrderCommand.OrderStatus command) {
-        Order order = orderRepository.findById(command.getOrderId());
-        order.updateOrderStatus(OrderStatus.from(command.getStatus()));
+    public void complete(String orderNumber) {
+        Order order = orderRepository.findByOrderNumber(orderNumber);
+        order.updateOrderStatus(OrderStatus.COMPLETE);
     }
 
     public OrderInfo.OrderDetail getOrderDetail(OrderCommand.OrderDetail command) {
@@ -41,7 +41,7 @@ public class OrderService {
                 order.getOrderStatus().getValue(),
                 OrderInfo.OrderProducts.of(
                         orderProductsByOrderId.stream()
-                                .map(orderProduct -> OrderInfo.OrderProduct.of(
+                                .map(orderProduct -> OrderInfo.OrderProductDto.of(
                                         orderProduct.getProductId(),
                                         orderProduct.getQuantity(),
                                         orderProduct.getPrice()))
@@ -61,7 +61,7 @@ public class OrderService {
                                 order.getTotalPrice(),
                                 OrderInfo.OrderProducts.of(
                                         order.getOrderProducts().stream()
-                                                .map(orderProduct -> OrderInfo.OrderProduct.of(
+                                                .map(orderProduct -> OrderInfo.OrderProductDto.of(
                                                         orderProduct.getProductId(),
                                                         orderProduct.getQuantity(),
                                                         orderProduct.getPrice()))
@@ -70,5 +70,11 @@ public class OrderService {
                                 order.getOrderStatus().getValue()
                         )).toList()
         );
+    }
+
+    public OrderInfo.OrderProducts getOrderProducts(String orderNumber) {
+        Order order = orderRepository.findByOrderNumber(orderNumber);
+        return OrderInfo.OrderProducts.from(order.getOrderProducts());
+
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CardType {
+    SAMSUNG("SAMSUNG"),
+    KB("KB"),
+    HYUNDAI("HYUNDAI"),
+    ;
+
+    public static CardType from(String input) {
+        for (CardType type : values()) {
+            if (type.name.equalsIgnoreCase(input)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("지원하지 않는 카드 타입입니다.");
+    }
+
+    private final String name;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @Entity
 @Table(name = "payment")
@@ -21,26 +22,75 @@ public class Payment {
 
     private Long orderId;
 
+    private String orderNumber;
+
     private Long amount;
 
+    @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
 
+    @Enumerated(EnumType.STRING)
+    private PaymentType paymentType;
+
+    @Enumerated(EnumType.STRING)
+    private CardType cardType;
+
     @Builder
-    private Payment(Long orderId, Long amount, PaymentStatus paymentStatus) {
+    private Payment(Long orderId, Long amount, String orderNumber, PaymentStatus paymentStatus, PaymentType paymentType, CardType cardType) {
         this.orderId = orderId;
         this.amount = amount;
+        this.orderNumber = orderNumber;
         this.paymentStatus = paymentStatus;
+        this.paymentType = paymentType;
+        this.cardType = cardType;
     }
 
-    public static Payment create(Long orderId, Long amount) {
+    public static Payment cardPaymentCreate(Long orderId, Long amount, String orderNumber, CardType cardType) {
+        return create(orderId, amount, orderNumber, PaymentType.CARD, cardType);
+    }
+
+    public static Payment pointPaymentCreate(Long orderId, Long amount, String orderNumber) {
+        return create(orderId, amount, orderNumber, PaymentType.POINT, null);
+    }
+
+    public static Payment create(Long orderId, Long amount, String orderNumber, PaymentType paymentType, CardType cardType) {
         validationOrderId(orderId);
         validationAmount(amount);
+        validationOrderNumber(orderNumber);
+        validationPaymentType(paymentType);
+
+        if(paymentType == PaymentType.CARD && cardType == null) {
+            throw new IllegalArgumentException("결제타입이 카드인 경우 ,카드 타입은 필수입니다.");
+        }
+
+        if(paymentType == PaymentType.POINT && cardType != null) {
+            throw new IllegalArgumentException("포인트 결제 시, 카드 타입을 지정할 수 없습니다.");
+        }
 
         return Payment.builder()
                 .orderId(orderId)
                 .amount(amount)
+                .orderNumber(orderNumber)
                 .paymentStatus(PaymentStatus.READY)
+                .paymentType(paymentType)
+                .cardType(cardType)
                 .build();
+    }
+
+    public static void validationPaymentType(PaymentType paymentType) {
+        if(paymentType == null) {
+            throw new IllegalArgumentException("결제 타입은 필수압니다.");
+        }
+    }
+
+    public static void validationOrderNumber(String orderNumber) {
+        if(orderNumber == null || orderNumber.isBlank()) {
+            throw new IllegalArgumentException("주문번호는 필수입니다.");
+        }
+
+        if (orderNumber.length() < 6) {
+            throw new IllegalArgumentException("주문 번호는 6자리보다 커야합니다.");
+        }
     }
 
     private static void validationAmount(Long amount) {
@@ -58,5 +108,10 @@ public class Payment {
     public void pay() {
         this.paymentStatus = PaymentStatus.PAID;
     }
+
+    public void pending() {
+        this.paymentStatus = PaymentStatus.PENDING;
+    }
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -10,16 +10,35 @@ public class PaymentCommand {
     public static class Pay {
         private Long amount;
         private Long orderId;
+        private String orderNumber;
+        private PaymentType paymentType;
+        private CardType cardType;
 
-        private Pay(Long amount, Long orderId) {
+        private Pay(Long amount, Long orderId, String orderNumber, PaymentType paymentType, CardType cardType) {
             this.amount = amount;
             this.orderId = orderId;
+            this.orderNumber = orderNumber;
+            this.paymentType = paymentType;
+            this.cardType = cardType;
         }
 
-        public static PaymentCommand.Pay of(Long amount, Long orderId) {
-            return PaymentCommand.Pay.builder()
+        public static PaymentCommand.Pay ofPoint(Long amount, Long orderId, String orderNumber) {
+            return Pay.builder()
                     .amount(amount)
                     .orderId(orderId)
+                    .orderNumber(orderNumber)
+                    .paymentType(PaymentType.POINT)
+                    .cardType(null)
+                    .build();
+        }
+
+        public static PaymentCommand.Pay ofCard(Long amount, Long orderId, String orderNumber, CardType cardType) {
+            return Pay.builder()
+                    .amount(amount)
+                    .orderId(orderId)
+                    .orderNumber(orderNumber)
+                    .paymentType(PaymentType.CARD)
+                    .cardType(cardType)
                     .build();
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
@@ -28,4 +28,38 @@ public class PaymentInfo {
             return  Payment.builder().paymentId(paymentId).amount(amount).orderId(orderId).paymentStatus(paymentStatus).build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class PaymentDetail {
+        String transactionKey;
+        String orderNumber;
+        CardType cardType;
+        String cardNo;
+        Long amount;
+        String status;
+        String reason;
+
+        private PaymentDetail(String transactionKey, String orderNumber, CardType cardType, String cardNo, Long amount, String status, String reason) {
+            this.transactionKey = transactionKey;
+            this.orderNumber = orderNumber;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.status = status;
+            this.reason = reason;
+        }
+
+        public static PaymentDetail of(String transactionKey, String orderNumber, CardType cardType, String cardNo, Long amount, String status, String reason) {
+            return PaymentDetail.builder()
+                    .transactionKey(transactionKey)
+                    .orderNumber(orderNumber)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
+                    .amount(amount)
+                    .status(status)
+                    .reason(reason)
+                    .build();
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -4,5 +4,7 @@ public interface PaymentRepository {
 
     Payment findById(Long id);
 
+    Payment findByOrderNumber(String orderNumber);
+
     Payment save(Payment payment);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -12,13 +12,25 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
 
     @Transactional
-    public PaymentInfo.Payment pay(PaymentCommand.Pay pay) {
-        Payment payment = Payment.create(pay.getOrderId(), pay.getAmount());
-        payment.pay();
+    public PaymentInfo.Payment create(PaymentCommand.Pay pay) {
+        Payment payment = Payment.create(pay.getOrderId(), pay.getAmount(), pay.getOrderNumber(), pay.getPaymentType(), pay.getCardType());
 
         Payment result = paymentRepository.save(payment);
 
         return PaymentInfo.Payment.of(result.getId(), result.getAmount(), result.getOrderId(), result.getPaymentStatus().getValue());
     }
 
+    @Transactional
+    public PaymentInfo.Payment pay(String orderNumber) {
+        Payment payment = paymentRepository.findByOrderNumber(orderNumber);
+        payment.pay();
+
+        return PaymentInfo.Payment.of(payment.getId(), payment.getAmount(), payment.getOrderId(), payment.getPaymentStatus().getValue());
+    }
+
+    @Transactional
+    public void pending(String orderNumber) {
+        Payment payment = paymentRepository.findByOrderNumber(orderNumber);
+        payment.pending();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum PaymentStatus {
 
     READY("READY"),
+    PENDING("PENDING"),
     PAID("PAID"),
     CANCEL("CANCEL")
     ;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentType {
+
+    POINT("POINT"),
+    CARD("CARD");
+
+    public static PaymentType from(String input) {
+        for (PaymentType type : values()) {
+            if (type.type.equalsIgnoreCase(input)) {
+                return type;
+            }
+        }
+
+        throw new IllegalArgumentException("유효하지 않은 결제 타입입니다.");
+    }
+
+    private final String type;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgClient.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.pg;
+
+public interface PgClient {
+
+    PgCommonResponse<PgInfo.PaymentResult> requestPayment(String userId, PgCommand.PaymentRequest request);
+
+    PgCommonResponse<PgInfo.PaymentDetail> getPaymentDetail(String userId, String transactionKey);
+
+    PgCommonResponse<PgInfo.PaymentSearchResult> getPaymentByOrderId(String userId, String orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgCommand.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.payment.CardType;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PgCommand {
+
+    @Getter
+    @Builder
+    public static class PaymentRequest {
+        private String orderId;
+        private CardType cardType;
+        private String cardNo;
+        private String amount;
+        private String callbackUrl;
+
+        private PaymentRequest(String orderId, CardType cardType, String cardNo, String amount, String callbackUrl) {
+            this.orderId = orderId;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.callbackUrl = callbackUrl;
+        }
+
+        public static PaymentRequest of(String orderId, CardType cardType, String cardNo, String amount, String callbackUrl) {
+            return PaymentRequest.builder()
+                    .orderId(orderId)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
+                    .amount(amount)
+                    .callbackUrl(callbackUrl)
+                    .build();
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgCommonResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgCommonResponse.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.pg;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PgCommonResponse<T> {
+    private Meta meta;
+    private T data;
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Meta {
+        private String result;
+        private String errorCode;
+        private String message;
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgConstant.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgConstant.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.pg;
+
+public class PgConstant {
+
+    public static final String PAYMENT_REQUEST_CALLBACK = "http://localhost:8080/api/v1/payment/callback";
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistory.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.payment.CardType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "pg_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PgHistory extends BaseEntity {
+    @Id
+    @Column(name = "pg_history_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userId;
+
+    private String orderNumber;
+
+    private String cardNo;
+
+    @Enumerated(EnumType.STRING)
+    private PgStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private CardType cardType;
+
+    private Long amount;
+
+
+
+    @Builder
+    private PgHistory(Long id, String userId, String orderNumber, String cardNo, PgStatus status, CardType cardType, Long amount) {
+        this.id = id;
+        this.userId = userId;
+        this.orderNumber = orderNumber;
+        this.cardNo = cardNo;
+        this.status = status;
+        this.cardType = cardType;
+        this.amount = amount;
+    }
+
+    public static PgHistory create(String userId, String orderNumber, String cardNo, PgStatus status, CardType cardType, Long amount) {
+        return PgHistory.builder()
+                .userId(userId)
+                .orderNumber(orderNumber)
+                .cardNo(cardNo)
+                .status(status)
+                .cardType(cardType)
+                .amount(amount)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryCommand.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.pg;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class PgHistoryCommand {
+
+    @Getter
+    @Builder
+    public static class Done {
+        private Long historyId;
+        private String userId;
+        private String orderNumber;
+
+        private Done(Long historyId, String userId, String orderNumber) {
+            this.historyId = historyId;
+            this.userId = userId;
+            this.orderNumber = orderNumber;
+        }
+
+        public static Done of(Long historyId, String userId, String orderNumber) {
+            return Done.builder()
+                    .historyId(historyId)
+                    .userId(userId)
+                    .orderNumber(orderNumber)
+                    .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryInfo.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.payment.CardType;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PgHistoryInfo {
+
+    @Getter
+    @Builder
+    public static class Failed {
+        private String userId;
+        private String orderNumber;
+        private String cardNo;
+        private Long amount;
+        private CardType cardType;
+        private PgStatus status;
+
+        private Failed(String userId, String orderNumber, String cardNo, Long amount, CardType cardType, PgStatus status) {
+            this.userId = userId;
+            this.orderNumber = orderNumber;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.cardType = cardType;
+            this.status = status;
+        }
+
+        public static Failed from(PgHistory pgHistory) {
+            return Failed.builder()
+                    .userId(pgHistory.getUserId())
+                    .orderNumber(pgHistory.getOrderNumber())
+                    .cardNo(pgHistory.getCardNo())
+                    .amount(pgHistory.getAmount())
+                    .cardType(pgHistory.getCardType())
+                    .status(pgHistory.getStatus())
+                    .build();
+        }
+
+        public static Failed of(String userId, String orderNumber, String cardNo, Long amount, CardType cardType) {
+            return Failed.builder()
+                    .userId(userId)
+                    .orderNumber(orderNumber)
+                    .cardNo(cardNo)
+                    .amount(amount)
+                    .cardType(cardType)
+                    .status(PgStatus.FAILED)
+                    .build();
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.pg;
+
+import java.util.List;
+
+public interface PgHistoryRepository {
+
+    PgHistory save(PgHistory pgHistory);
+
+    List<PgHistory> findListByStatus(PgStatus status);
+
+    int updateStatus(String orderNumber, PgStatus status);
+
+    void touchByOrderNumbers(List<String> orderNumbers);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgHistoryService.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.pg;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PgHistoryService {
+
+    private final PgHistoryRepository pgHistoryRepository;
+
+    public List<PgHistoryInfo.Failed> getPaymentFailedList() {
+        List<PgHistory> list = pgHistoryRepository.findListByStatus(PgStatus.FAILED);
+        return list.stream().map(PgHistoryInfo.Failed::from).toList();
+    }
+
+    public void complete(String orderNumber) {
+        pgHistoryRepository.updateStatus(orderNumber, PgStatus.SUCCESS);
+    }
+
+    public void touch(List<String> orderNumbers) {
+        pgHistoryRepository.touchByOrderNumbers(orderNumbers);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgInfo.java
@@ -1,0 +1,97 @@
+package com.loopers.domain.pg;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class PgInfo {
+
+    @Getter
+    @Builder
+    public static class PaymentResult {
+        private String transactionKey;
+        private String status;
+
+        private PaymentResult(String status, String transactionKey) {
+            this.status = status;
+            this.transactionKey = transactionKey;
+        }
+
+        public static PaymentResult of(String status, String transactionKey) {
+            return PaymentResult.builder().status(status).transactionKey(transactionKey).build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class PaymentDetail {
+        private String transactionKey;
+        private String orderId;
+        private String cardType;
+        private String cardNo;
+        private String amount;
+        private PgStatus status;
+        private String reason;
+
+        private PaymentDetail(String transactionKey, String orderId, String cardType, String cardNo, String amount, PgStatus status, String reason) {
+            this.transactionKey = transactionKey;
+            this.orderId = orderId;
+            this.cardType = cardType;
+            this.cardNo = cardNo;
+            this.amount = amount;
+            this.status = status;
+            this.reason = reason;
+        }
+
+        public static PaymentDetail of(String transactionKey, String orderId, String cardType, String cardNo, String amount, PgStatus status, String reason) {
+            return
+                    PaymentDetail.builder()
+                            .transactionKey(transactionKey)
+                            .orderId(orderId)
+                            .cardType(cardType)
+                            .cardNo(cardNo)
+                            .amount(amount)
+                            .status(status)
+                            .reason(reason)
+                            .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class PaymentSearchResult {
+        private String orderId;
+        private List<Transaction> transactions;
+
+        private PaymentSearchResult(String orderId, List<Transaction> transactions) {
+            this.orderId = orderId;
+            this.transactions = transactions;
+        }
+
+        public static PaymentSearchResult of(String orderId, List<Transaction> transactions) {
+            return PaymentSearchResult.builder()
+                    .orderId(orderId)
+                    .transactions(transactions)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Transaction {
+        private String transactionKey;
+        private String status;
+        private String reason;
+
+        private Transaction(String reason, String status, String transactionKey) {
+            this.reason = reason;
+            this.status = status;
+            this.transactionKey = transactionKey;
+        }
+
+        public static Transaction of(String reason, String status, String transactionKey) {
+            return Transaction.builder().reason(reason).status(status).transactionKey(transactionKey).build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgService.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.pg;
+
+import com.loopers.support.error.PgServiceRetryException;
+import com.loopers.support.error.PgServiceUnavailableException;
+import com.loopers.support.error.RetryableBusinessException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PgService {
+
+    private final PgClient pgClient;
+
+    private final PgHistoryRepository pgHistoryRepository;
+
+
+    @Retry(name = "pgRetry", fallbackMethod = "requestPaymentRetryFallback")
+    @CircuitBreaker(name = "pgCircuit", fallbackMethod = "requestPaymentCircuitFallback")
+    public PgInfo.PaymentResult requestPayment(String userId, PgCommand.PaymentRequest request) {
+        PgCommonResponse<PgInfo.PaymentResult> result = pgClient.requestPayment(userId, request);
+        if(!result.getMeta().getResult().equals("SUCCESS")) {
+            throw new RetryableBusinessException("PG 응답 실패했습니다.");
+        }
+
+        return result.getData();
+    }
+
+    public PgInfo.PaymentResult requestPaymentRetryFallback(String userId, PgCommand.PaymentRequest request, Throwable throwable) {
+        pgHistoryRepository.save(PgHistory.create(userId, request.getOrderId(), request.getCardNo(),
+                PgStatus.FAILED,
+                request.getCardType(),
+                Long.valueOf(request.getAmount())
+                ));
+        throw new PgServiceRetryException("PG 서버가 불안정합니다. 잠시후 재시도해주세요.");
+    }
+
+    public PgInfo.PaymentResult requestPaymentCircuitFallback(String userId, PgCommand.PaymentRequest request, Throwable throwable) {
+        pgHistoryRepository.save(PgHistory.create(userId, request.getOrderId(), request.getCardNo(),
+                PgStatus.FAILED,
+                request.getCardType(),
+                Long.valueOf(request.getAmount())
+        ));
+        throw new PgServiceUnavailableException("결제 요청에 실패했습니다. 잠시후 재시도해주세요.");
+    }
+
+    @Retry(name = "pgRetry", fallbackMethod = "getPaymentDetailRetryFallback")
+    @CircuitBreaker(name = "pgCircuit", fallbackMethod = "getPaymentDetailCircuitFallback")
+    public PgInfo.PaymentDetail getPaymentDetail(String userId, String transactionId) {
+        PgCommonResponse<PgInfo.PaymentDetail> result = pgClient.getPaymentDetail(userId, transactionId);
+        if(!result.getMeta().getResult().equals("SUCCESS")) {
+            throw new RetryableBusinessException("PG 응답 실패했습니다.");
+        }
+
+        return PgInfo.PaymentDetail.of(result.getData().getTransactionKey(),
+        result.getData().getOrderId(),
+        result.getData().getCardType(),
+        result.getData().getCardNo(),
+        result.getData().getAmount(),
+        result.getData().getStatus(),
+                result.getData().getReason()
+                );
+    }
+
+    public void getPaymentDetailCircuitFallback(String userId, String transactionId, Throwable throwable) {
+        throw new PgServiceUnavailableException("PG 결제 상태 조회 실패했습니다. 잠시후 재시도해주세요.", throwable);
+    }
+
+    public void getPaymentDetailRetryFallback(String userId, String transactionId, Throwable throwable) {
+        throw new PgServiceRetryException("PG 서버가 불안정합니다. 잠시후 재시도해주세요.", throwable);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgStatus.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.pg;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PgStatus {
+
+    FAILED("FAILED"),
+    PENDING("PENDING"),
+    SUCCESS("SUCCESS"),
+    ;
+
+    private final String status;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByUserId(String userId);
+
+    Order findByOrderNumber(String orderNumber);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -31,6 +31,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
+    public Order findByOrderNumber(String orderNumber) {
+        return orderJpaRepository.findByOrderNumber(orderNumber);
+    }
+
+    @Override
     public List<OrderProduct> findOrderProductsByOrderId(Long orderId) {
         return orderProductJpaRepository.findOrderProductsByOrderId(orderId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -4,4 +4,5 @@ import com.loopers.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+    Payment findByOrderNumber(String orderNumber);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -20,6 +20,12 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public Payment findByOrderNumber(String orderNumber) {
+        return paymentJpaRepository.findByOrderNumber(orderNumber);
+    }
+
+
+    @Override
     public Payment save(Payment payment) {
         return paymentJpaRepository.save(payment);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientImpl.java
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.pg.PgClient;
+import com.loopers.domain.pg.PgCommand;
+import com.loopers.domain.pg.PgCommonResponse;
+import com.loopers.domain.pg.PgInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PgClientImpl implements PgClient {
+
+    private final PgFeignClient pgFeignClient;
+
+    @Override
+    public PgCommonResponse<PgInfo.PaymentResult> requestPayment(String userId, PgCommand.PaymentRequest request) {
+        return pgFeignClient.requestPayment(userId, request);
+    }
+
+    @Override
+    public PgCommonResponse<PgInfo.PaymentDetail> getPaymentDetail(String userId, String transactionKey) {
+        return pgFeignClient.getPaymentDetail(userId, transactionKey);
+    }
+
+    @Override
+    public PgCommonResponse<PgInfo.PaymentSearchResult> getPaymentByOrderId(String userId, String orderId) {
+        return pgFeignClient.getPaymentByOrderId(userId, orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignClient.java
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.config.PgFeignClientConfig;
+import com.loopers.domain.pg.PgCommand;
+import com.loopers.domain.pg.PgCommonResponse;
+import com.loopers.domain.pg.PgInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name = "pgClient", url = "${pg.simulator.url}", configuration = PgFeignClientConfig.class)
+public interface PgFeignClient {
+
+    @PostMapping("/api/v1/payments")
+    PgCommonResponse<PgInfo.PaymentResult> requestPayment(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestBody PgCommand.PaymentRequest request
+    );
+
+    @GetMapping("/api/v1/payments/{transactionKey}")
+    PgCommonResponse<PgInfo.PaymentDetail> getPaymentDetail(
+            @RequestHeader("X-USER-ID") String userId,
+            @PathVariable("transactionKey") String transactionKey
+    );
+
+    @GetMapping("/api/v1/payments")
+    PgCommonResponse<PgInfo.PaymentSearchResult> getPaymentByOrderId(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestParam("orderId") String orderId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgHistoryJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgHistoryJpaRepository.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.pg.PgHistory;
+import com.loopers.domain.pg.PgStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PgHistoryJpaRepository extends JpaRepository<PgHistory, Long> {
+
+    List<PgHistory> findByStatus(PgStatus status);
+
+
+    @Modifying
+    @Query("UPDATE PgHistory ph SET ph.status = :status WHERE ph.orderNumber = :orderNumber")
+    int updateStatusByIds(@Param("status") PgStatus status, @Param("orderNumber") String orderNumber);
+
+    @Modifying
+    @Query("UPDATE PgHistory p SET p.updatedAt = CURRENT_TIMESTAMP WHERE p.orderNumber IN :orderNumbers")
+    void touchByOrderNumbers(@Param("orderNumbers") List<String> orderNumbers);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgHistoryRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgHistoryRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.pg.PgHistory;
+import com.loopers.domain.pg.PgHistoryRepository;
+import com.loopers.domain.pg.PgStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PgHistoryRepositoryImpl implements PgHistoryRepository {
+    private final PgHistoryJpaRepository pgHistoryJpaRepository;
+
+
+    @Override
+    public PgHistory save(PgHistory pgHistory) {
+        return pgHistoryJpaRepository.save(pgHistory);
+    }
+
+    @Override
+    public List<PgHistory> findListByStatus(PgStatus status) {
+        return pgHistoryJpaRepository.findByStatus(status);
+    }
+
+    @Override
+    public int updateStatus(String orderNumber, PgStatus status) {
+        return pgHistoryJpaRepository.updateStatusByIds(status, orderNumber);
+    }
+
+    @Override
+    public void touchByOrderNumbers(List<String> orderNumbers) {
+        pgHistoryJpaRepository.touchByOrderNumbers(orderNumbers);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import com.loopers.support.error.PgServiceRetryException;
+import com.loopers.support.error.PgServiceUnavailableException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -134,6 +137,21 @@ public class ApiControllerAdvice {
     @ExceptionHandler
     public ResponseEntity<ApiResponse<?>> handleNotFound(NoResourceFoundException e) {
         return failureResponse(ErrorType.NOT_FOUND, null);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handlePgRetryException(PgServiceRetryException e) {
+        return failureResponse(ErrorType.PG_INTERNAL_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handlePgUnAvailableException(PgServiceUnavailableException e) {
+        return failureResponse(ErrorType.PG_INTERNAL_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleCircuitException(CallNotPermittedException e) {
+        return failureResponse(ErrorType.CC_INTERNAL_ERROR, e.getMessage());
     }
 
     @ExceptionHandler

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
@@ -1,13 +1,15 @@
 package com.loopers.interfaces.api.order;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.loopers.application.order.OrderCriteria;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class OrderRequest {
+
 
     @Getter
     @Setter
@@ -16,17 +18,33 @@ public class OrderRequest {
     public static class Order {
         private List<OrderProduct> orderProducts;
         private Long couponId;
+        private PaymentTypeDto paymentTypeDto;
+        private CardTypeDto cardTypeDto;
+        private String cardNo;
 
-        public Order(List<OrderProduct> orderProducts, Long couponId) {
+        public Order(List<OrderProduct> orderProducts, Long couponId, PaymentTypeDto paymentTypeDto, CardTypeDto cardTypeDto, String cardNo) {
             this.orderProducts = orderProducts;
             this.couponId = couponId;
+            this.paymentTypeDto = paymentTypeDto;
+            this.cardTypeDto = cardTypeDto;
+            this.cardNo = cardNo;
         }
 
-        public static Order of(List<OrderProduct> orderItems, Long couponId) {
+        public static Order of(List<OrderProduct> orderItems, Long couponId, PaymentTypeDto paymentTypeDto, CardTypeDto cardTypeDto, String cardNo) {
             return Order.builder()
                     .orderProducts(orderItems)
                     .couponId(couponId)
+                    .paymentTypeDto(paymentTypeDto)
+                    .cardTypeDto(cardTypeDto)
+                    .cardNo(cardNo)
                     .build();
+        }
+
+        public OrderCriteria.Order toOrderCriteria(String userId) {
+            return OrderCriteria.Order.of(userId, this.getOrderProducts().stream()
+                    .map(op -> OrderCriteria.OrderProduct.of(op.getProductId(), op.getQuantity()))
+                    .collect(Collectors.toList()), this.getCouponId(), this.getPaymentTypeDto().toPaymentType(),
+                    this.getPaymentTypeDto() == PaymentTypeDto.CARD ? this.getCardTypeDto().toCardType() : null, cardNo);
         }
     }
 
@@ -48,6 +66,37 @@ public class OrderRequest {
                     .productId(productId)
                     .quantity(quantity)
                     .build();
+        }
+    }
+
+
+    @Getter
+    @RequiredArgsConstructor
+    public static enum PaymentTypeDto {
+
+        POINT("POINT"),
+        CARD("CARD"),
+        ;
+
+        private final String type;
+
+        public PaymentType toPaymentType() {
+            return PaymentType.valueOf(this.name());
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static enum CardTypeDto {
+        SAMSUNG("SAMSUNG"),
+        KB("KB"),
+        HYUNDAI("HYUNDAI"),
+        ;
+
+        private final String name;
+
+        public CardType toCardType() {
+            return CardType.valueOf(this.name());
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
@@ -1,4 +1,25 @@
 package com.loopers.interfaces.api.order;
 
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+
 public interface OrderV1ApiSpec {
+
+    @Operation(
+            summary = "주문",
+            description = "주문 및 결제를 진행합니다."
+    )
+    ApiResponse<Void> order(String userId, OrderRequest.Order order);
+
+    @Operation(
+            summary = "주문 목록 조회",
+            description = "사용자의 주문 목록을 조회합니다."
+    )
+    ApiResponse<OrderResponse.Orders> getOrders(String userId);
+
+    @Operation(
+            summary = "주문 상세 조회",
+            description = "사용자 주문을 상세 조회합니다."
+    )
+    ApiResponse<OrderResponse.Order> getOrder(String userId, Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/orders")
-public class OrderV1Controller {
+public class OrderV1Controller implements OrderV1ApiSpec{
 
     private final OrderFacade orderFacade;
 
@@ -23,9 +23,8 @@ public class OrderV1Controller {
             @RequestHeader(value = "X-USER-ID", required = true) String userId,
             @RequestBody OrderRequest.Order order) {
 
-        orderFacade.order(OrderCriteria.Order.of(userId, order.getOrderProducts().stream()
-                .map(op -> OrderCriteria.OrderProduct.of(op.getProductId(), op.getQuantity()))
-                .collect(Collectors.toList()), order.getCouponId()));
+        orderFacade.order(order.toOrderCriteria(userId));
+
         return ApiResponse.success();
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentController.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.PaymentCriteria;
+import com.loopers.application.payment.PaymentFacade;
+import com.loopers.domain.pg.PgCommonResponse;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/payment")
+@RequiredArgsConstructor
+public class PaymentController implements PaymentV1ApiSpec{
+
+    private final PaymentFacade paymentFacade;
+
+    @PostMapping("/callback")
+    public ApiResponse<Void> paymentCallback(@RequestBody PaymentRequest.TransactionInfo transactionInfo) {
+        paymentFacade.processPaymentResult(transactionInfo.toPaymentResult());
+        return ApiResponse.success();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentRequest.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.PaymentCriteria;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class PaymentRequest {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ToString
+    public static class TransactionInfo {
+        private String transactionKey;
+        private String orderId;
+        private String cardType;
+        private String cardNo;
+        private Long amount;
+        private String status;
+        private String reason;
+
+        public PaymentCriteria.PaymentResult toPaymentResult() {
+            return PaymentCriteria.PaymentResult.builder()
+                    .transactionKey(transactionKey)
+                    .orderId(orderId)
+                    .cardType(cardType)
+                    .cardNo(cardNo)
+                    .amount(amount)
+                    .status(status)
+                    .reason(reason)
+                    .build();
+        }
+    }
+
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -1,0 +1,17 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.domain.pg.PgCommonResponse;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.point.PointResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PaymentV1ApiSpec {
+
+
+    @Operation(
+            summary = "결제 요청 callback",
+            description = "결제 요청에 대한 응답을 비동기로 전달받아 결재 상태를 변경합니다."
+    )
+    ApiResponse<Void> paymentCallback(PaymentRequest.TransactionInfo transactionInfo);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/scheduler/PgRetryScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/scheduler/PgRetryScheduler.java
@@ -1,0 +1,58 @@
+package com.loopers.scheduler;
+
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.pg.*;
+import com.loopers.support.error.PgServiceRetryException;
+import com.loopers.support.error.PgServiceUnavailableException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PgRetryScheduler {
+
+    private final PgHistoryService historyService;
+
+    private final OrderService orderService;
+
+    private final PgService pgService;
+
+    private final PaymentService paymentService;
+
+
+    @Scheduled(cron = "0 0/5 * * * *")
+    public void retryFailedPgRequests() {
+        List<PgHistoryInfo.Failed> paymentFailedList = historyService.getPaymentFailedList();
+
+        List<String> failedOrderNumbers = new ArrayList<>();
+
+        for (PgHistoryInfo.Failed failed : paymentFailedList) {
+            try {
+
+                PgCommand.PaymentRequest retryRequest = PgCommand.PaymentRequest.of(
+                        failed.getOrderNumber(),
+                        failed.getCardType(),
+                        failed.getCardNo(),
+                        String.valueOf(failed.getAmount()),
+                        PgConstant.PAYMENT_REQUEST_CALLBACK
+                );
+
+                pgService.requestPayment(failed.getUserId(), retryRequest);
+                paymentService.pay(failed.getOrderNumber());
+                orderService.complete(failed.getOrderNumber());
+                historyService.complete(failed.getOrderNumber());
+            } catch (PgServiceRetryException | PgServiceUnavailableException ignored) {
+                failedOrderNumbers.add(failed.getOrderNumber());
+            }
+        }
+
+        if(!failedOrderNumbers.isEmpty()) {
+            historyService.touch(failedOrderNumbers);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -12,8 +12,15 @@ public enum ErrorType {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.getReasonPhrase(), "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.getReasonPhrase(), "인증되지 않은 사용자입니다."),
 
+    /** PG 에러 */
+    PG_INTERNAL_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "PG-2001", "PG 서버 내부 오류입니다."),
+
+
+    /** Circuit 에러 */
+    CC_INTERNAL_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "CC-4001", "서비스가 일시적으로 불안정합니다."),
+        ;
 
 
     private final HttpStatus status;

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/PgServiceRetryException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/PgServiceRetryException.java
@@ -1,0 +1,12 @@
+package com.loopers.support.error;
+
+public class PgServiceRetryException extends RuntimeException {
+
+    public PgServiceRetryException(String message) {
+        super(message);
+    }
+
+    public PgServiceRetryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/PgServiceUnavailableException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/PgServiceUnavailableException.java
@@ -1,0 +1,12 @@
+package com.loopers.support.error;
+
+public class PgServiceUnavailableException extends RuntimeException {
+
+    public PgServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public PgServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/RetryableBusinessException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/RetryableBusinessException.java
@@ -1,0 +1,13 @@
+package com.loopers.support.error;
+
+public class RetryableBusinessException extends RuntimeException {
+
+    public RetryableBusinessException(String message) {
+        super(message);
+    }
+
+    public RetryableBusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -29,6 +29,32 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+
+pg:
+  simulator:
+    url: http://localhost:8082
+
+resilience4j:
+  retry:
+    instances:
+      pgRetry:
+        max-attempts: 3
+        wait-duration: 1s
+        retry-exceptions:
+          - feign.RetryableException
+          - com.loopers.support.error.RetryableBusinessException
+        fail-after-max-attempts: true
+  circuitbreaker:
+    instances:
+      pgCircuit:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 2
+        minimum-number-of-calls: 5
+        slow-call-duration-threshold: 3s
+        slow-call-rate-threshold: 50
+
 ---
 spring:
   config:

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -22,7 +22,6 @@ import com.loopers.domain.usercoupon.UserCouponStatus;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -101,7 +100,7 @@ class OrderFacadeIntegrationTest {
         @DisplayName("주문 상품 리스트가 비어있을 경우 BAD_REQUEST 예외가 발생한다.")
         void throwBadRequest_whenOrderProductListIsEmpty() {
             // given
-            OrderCriteria.Order order = OrderCriteria.Order.of(userId, List.of(), 1L);
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(userId, List.of(), 1L);
 
             // when
             CoreException ex = assertThrows(CoreException.class, () -> {
@@ -117,7 +116,7 @@ class OrderFacadeIntegrationTest {
         @DisplayName("로그인되지 않은 사용자의 주문 시 404 Not Found 예외가 발생한다.")
         void throwUnauthorized_whenUserIdIsNull() {
             // given
-            OrderCriteria.Order order = OrderCriteria.Order.of(null, List.of(
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(null, List.of(
                     OrderCriteria.OrderProduct.of(1L, 1L)
             ), 1L);
 
@@ -154,7 +153,7 @@ class OrderFacadeIntegrationTest {
             stockRepository.save(Stock.create(product.getId(), 1L));
             pointRepository.save(Point.create(user.getId(), 5000L));
 
-            OrderCriteria.Order order = OrderCriteria.Order.of(user.getId(), List.of(
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(user.getId(), List.of(
                     OrderCriteria.OrderProduct.of(product.getId(), 5L)
             ), coupon.getId());
 
@@ -190,7 +189,7 @@ class OrderFacadeIntegrationTest {
             stockRepository.save(Stock.create(product.getId(), 10L));
             pointRepository.save(Point.create(user.getId(), 5000L));
 
-            OrderCriteria.Order order = OrderCriteria.Order.of(user.getId(), List.of(
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(user.getId(), List.of(
                     OrderCriteria.OrderProduct.of(product.getId(), 1L)
             ), userCoupon.getCouponId());
 
@@ -241,7 +240,7 @@ class OrderFacadeIntegrationTest {
             UserCouponRepository.save(UserCoupon.create(userId, coupon.getId()));
 
 
-            OrderCriteria.Order order = OrderCriteria.Order.of(userId, List.of(
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(userId, List.of(
                     OrderCriteria.OrderProduct.of(product.getId(), 2L)
             ), coupon.getId());
             orderFacade.order(order);
@@ -283,7 +282,7 @@ class OrderFacadeIntegrationTest {
             stockRepository.save(Stock.create(product.getId(), 10L));
             pointRepository.save(Point.create(user.getId(), 5000L));
 
-            OrderCriteria.Order order = OrderCriteria.Order.of(user.getId(), List.of(
+            OrderCriteria.Order order = OrderCriteria.Order.ofPoint(user.getId(), List.of(
                     OrderCriteria.OrderProduct.of(product.getId(), 1L)
             ), userCoupon.getCouponId());
             orderFacade.order(order);
@@ -421,7 +420,7 @@ class OrderFacadeIntegrationTest {
                     .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
                         try {
                             start.await();
-                            OrderCriteria.Order request = OrderCriteria.Order.of(
+                            OrderCriteria.Order request = OrderCriteria.Order.ofPoint(
                                     userId,
                                     products.stream()
                                             .map(p -> OrderCriteria.OrderProduct.of(p.getId(), quantityPerItem))
@@ -484,7 +483,7 @@ class OrderFacadeIntegrationTest {
                         ready.countDown();
                         start.await();
 
-                        OrderCriteria.Order request = OrderCriteria.Order.of(
+                        OrderCriteria.Order request = OrderCriteria.Order.ofPoint(
                                 userId,
                                 List.of(OrderCriteria.OrderProduct.of(product.getId(), quantityPerOrder)),
                                 null
@@ -516,7 +515,7 @@ class OrderFacadeIntegrationTest {
 
 
         private OrderCriteria.Order orderOf(String userId, Long productId, long qty, Long couponId) {
-            return OrderCriteria.Order.of(
+            return OrderCriteria.Order.ofPoint(
                     userId,
                     List.of(OrderCriteria.OrderProduct.of(productId, qty)),
                     couponId

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -66,7 +66,7 @@ class OrderServiceIntegrationTest {
             )));
 
             // when
-            orderService.pay(OrderCommand.OrderStatus.of(order.getId(), OrderStatus.COMPLETE.getValue()));
+            orderService.complete(order.getOrderNumber());
 
             // then
             Order updated = orderRepository.findById(order.getId());
@@ -87,7 +87,7 @@ class OrderServiceIntegrationTest {
 
             // then
             assertThat(detail.getOrderId()).isEqualTo(order.getId());
-            assertThat(detail.getOrderProducts().getOrderProducts()).hasSize(1);
+            assertThat(detail.getOrderProducts().getOrderProductDtos()).hasSize(1);
             assertThat(detail.getOrderStatus()).isEqualTo("PENDING");
         }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceIntegrationTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
@@ -39,10 +41,11 @@ class PaymentServiceIntegrationTest {
             Long orderId = 1L;
             Long amount = 10000L;
 
-            PaymentCommand.Pay command = PaymentCommand.Pay.of(amount, orderId);
+            PaymentCommand.Pay command = PaymentCommand.Pay.ofPoint(amount, orderId, UUID.randomUUID().toString());
 
             // when
-            PaymentInfo.Payment pay = paymentService.pay(command);
+            PaymentInfo.Payment pay = paymentService.create(command);
+            paymentService.pay(command.getOrderNumber());
 
             // then
             Payment saved = paymentRepository.findById(pay.getPaymentId());
@@ -55,10 +58,10 @@ class PaymentServiceIntegrationTest {
         @DisplayName("결제 금액이 null 또는 0 이하인 경우 예외가 발생한다")
         void shouldThrow_whenInvalidAmountGiven() {
             // given
-            PaymentCommand.Pay command = PaymentCommand.Pay.of(0L, 5000L);
+            PaymentCommand.Pay command = PaymentCommand.Pay.ofPoint(0L, 5000L, UUID.randomUUID().toString());
 
             // when & then
-            assertThatThrownBy(() -> paymentService.pay(command))
+            assertThatThrownBy(() -> paymentService.create(command))
                     .isInstanceOf(CoreException.class)
                     .hasMessage("유효하지 않은 금액입니다.");
         }
@@ -67,10 +70,10 @@ class PaymentServiceIntegrationTest {
         @DisplayName("주문 ID가 null 또는 0 이하인 경우 예외가 발생한다")
         void throwsException_whenOrderIdIsNullOrLessThanOrEqualToZero() {
             // given
-            PaymentCommand.Pay command = PaymentCommand.Pay.of(1L, 0L);
+            PaymentCommand.Pay command = PaymentCommand.Pay.ofPoint(1L, 0L, UUID.randomUUID().toString());
 
             // when & then
-            assertThatThrownBy(() -> paymentService.pay(command))
+            assertThatThrownBy(() -> paymentService.create(command))
                     .isInstanceOf(CoreException.class)
                     .hasMessage("유효하지 않은 주문 ID입니다.");
         }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -27,7 +29,7 @@ class PaymentTest {
 
             // when & then
             CoreException exception = assertThrows(CoreException.class, () -> {
-                Payment.create(orderId, amount);
+                Payment.pointPaymentCreate(orderId, amount, UUID.randomUUID().toString());
             });
 
             assertThat(exception)
@@ -45,7 +47,7 @@ class PaymentTest {
 
             // when & then
             CoreException exception = assertThrows(CoreException.class, () -> {
-                Payment.create(orderId, amount);
+                Payment.pointPaymentCreate(orderId, amount, UUID.randomUUID().toString());
             });
 
             assertThat(exception)
@@ -61,7 +63,7 @@ class PaymentTest {
             Long amount = 5000L;
 
             // when
-            Payment payment = Payment.create(orderId, amount);
+            Payment payment = Payment.pointPaymentCreate(orderId, amount, UUID.randomUUID().toString());
 
             // then
             assertThat(payment.getOrderId()).isEqualTo(orderId);
@@ -78,7 +80,7 @@ class PaymentTest {
         @DisplayName("pay() 호출 시 결제 상태가 PAID로 변경된다")
         void shouldChangeStatusToPaid() {
             // given
-            Payment payment = Payment.create(1L, 3000L);
+            Payment payment = Payment.pointPaymentCreate(1L, 3000L, UUID.randomUUID().toString());
 
             // when
             payment.pay();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgServiceTest.java
@@ -1,0 +1,455 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.support.error.PgServiceRetryException;
+import com.loopers.support.error.RetryableBusinessException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.AopTestUtils;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        // ---------- Retry(pgRetry) ----------
+        "resilience4j.retry.instances.pgRetry.max-attempts=3",
+        "resilience4j.retry.instances.pgRetry.wait-duration=1000ms",
+        "resilience4j.retry.instances.pgRetry.retry-exceptions=java.lang.RuntimeException," +
+                "com.loopers.support.error.RetryableBusinessException",
+        "resilience4j.retry.instances.pgRetry.fail-after-max-attempts=true",
+
+        // ---------- CircuitBreaker(pgCircuit) ----------
+        "resilience4j.circuitbreaker.instances.pgCircuit.minimum-number-of-calls=5",
+        "resilience4j.circuitbreaker.instances.pgCircuit.sliding-window-size=10",
+        "resilience4j.circuitbreaker.instances.pgCircuit.failure-rate-threshold=50",
+        "resilience4j.circuitbreaker.instances.pgCircuit.wait-duration-in-open-state=10s",
+        "resilience4j.circuitbreaker.instances.pgCircuit.permitted-number-of-calls-in-half-open-state=2",
+        "resilience4j.circuitbreaker.instances.pgCircuit.slow-call-duration-threshold= 3s",
+        "resilience4j.circuitbreaker.instances.pgCircuit.slow-call-rate-threshold= 50",
+
+
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class PgServiceTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        PgClient pgClient() {
+            return Mockito.mock(PgClient.class);
+        }
+
+        @Bean
+        @Primary
+        PgHistoryRepository pgHistoryRepository() {
+            return Mockito.mock(PgHistoryRepository.class);
+        }
+
+        @Bean
+        @Primary
+        PgService pgService(PgClient pgClient, PgHistoryRepository pgHistoryRepository) {
+            return Mockito.spy(new PgService(pgClient,pgHistoryRepository));
+        }
+    }
+
+
+    @Autowired
+    PgService pgService;
+
+    @Autowired
+    PgClient pgClient;
+
+    @Autowired
+    CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Value("${resilience4j.retry.instances.pgRetry.max-attempts}")
+    private int retryMaxAttemps;
+
+    @Value("${resilience4j.circuitbreaker.instances.pgCircuit.wait-duration-in-open-state}")
+    private String waitDurationInOpenState;
+
+    @Value("${resilience4j.circuitbreaker.instances.pgCircuit.permitted-number-of-calls-in-half-open-state}")
+    private int permittedNumberOfCallsInHalfOpenState;
+
+    private PgService targetSpy;
+
+    @BeforeEach
+    void resetMocks() throws Exception {
+        CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+        pgCircuit.reset();
+        targetSpy = AopTestUtils.getTargetObject(pgService);
+        Mockito.clearInvocations(pgClient, targetSpy);
+        Mockito.reset(pgClient, targetSpy);
+    }
+
+
+    private PgCommonResponse<PgInfo.PaymentResult> successResponse() {
+        return new PgCommonResponse<>(
+                PgCommonResponse.Meta.builder()
+                        .result("SUCCESS")
+                        .build(),
+                PgInfo.PaymentResult.builder()
+                        .status("PENDING")
+                        .transactionKey("20250818:TR:e2ad1b")
+                        .build()
+        );
+    }
+
+    private PgCommonResponse<PgInfo.PaymentResult> failResponse() {
+        return new PgCommonResponse<>(
+                PgCommonResponse.Meta.builder()
+                        .result("FAIL")
+                        .build(),
+                null
+        );
+    }
+
+    private PgCommand.PaymentRequest paymentRequest() {
+        return PgCommand.PaymentRequest.of(
+                "550e8400-e29b-41d4-a716-446655440000",
+                CardType.SAMSUNG,
+                "1234-5678-9814-1451",
+                "1000",
+                "http://localhost:8080/api/v1/payment/callback"
+        );
+    }
+
+    @DisplayName("@Retry 테스트")
+    @Nested
+    public class Retry {
+        @Test
+        @DisplayName("정상 응답이면 재시도 없이 1회 호출로 성공한다.")
+        void callOnce_whenReturnSuccess() {
+            // given
+            String userId = "userId";
+            PgCommonResponse<PgInfo.PaymentResult> successResponse = successResponse();
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+
+            // when
+            when(pgClient.requestPayment(userId, paymentRequest))
+                    .thenReturn(successResponse);
+
+            PgInfo.PaymentResult result =
+                    pgService.requestPayment(userId, paymentRequest);
+
+            // then
+            assertThat(result.getTransactionKey()).isEqualTo(successResponse.getData().getTransactionKey());
+            verify(pgClient, times(1)).requestPayment(any(), any());
+        }
+
+        @Test
+        @DisplayName("RetryableBusinessException 발생시 재시도를 시도하고, retryMaxAttemps 번째 성공시 정상 응답을 반환한다.")
+        void should_returnSuccess_when_thirdAttemptSucceeds_afterRetryableBusinessExceptions() {
+            // given
+            PgCommonResponse<PgInfo.PaymentResult> successResponse = successResponse();
+            String userId = "userId";
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+
+            // when
+            when(pgClient.requestPayment(eq(userId), any(PgCommand.PaymentRequest.class)))
+                    .thenThrow(new RetryableBusinessException("First"))
+                    .thenThrow(new RetryableBusinessException("Second"))
+                    .thenReturn(successResponse());
+
+            PgInfo.PaymentResult result =
+                    pgService.requestPayment(userId, paymentRequest);
+
+            // then
+            assertThat(result.getTransactionKey()).isEqualTo(successResponse.getData().getTransactionKey());
+            verify(pgClient, times(retryMaxAttemps)).requestPayment(eq(userId), any(PgCommand.PaymentRequest.class));
+        }
+
+        @Test
+        @DisplayName("정해진 재시도 횟수 초과 시, PgServiceRetryException 예외가 발생한다.")
+        void should_throwPgServiceRetryException_when_retryAttemptsExceeded() {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+
+            // when
+            when(pgClient.requestPayment(userId, paymentRequest))
+                    .thenReturn(failResponse());
+
+            // then
+            assertThatThrownBy(() ->
+                    pgService.requestPayment(userId, paymentRequest)
+            ).isInstanceOf(PgServiceRetryException.class)
+                    .hasMessageContaining("PG 서버가 불안정합니다. 잠시후 재시도해주세요.");
+
+            verify(pgClient, times(retryMaxAttemps)).requestPayment(any(), any());
+        }
+
+        @Test
+        @DisplayName("정해진 재시도 횟수 초과 시,  requestPaymentRetryFallback 함수가 호출된다.")
+        void should_CallRequestPaymentRetryFallbackFunction_when_retryAttemptsExceeded() {
+            String userId = "userId";
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+            PgCommonResponse<PgInfo.PaymentResult> failResponse = failResponse();
+
+            when(pgClient.requestPayment(userId, paymentRequest))
+                    .thenReturn(failResponse);
+
+            assertThatThrownBy(() ->
+                    pgService.requestPayment(userId, paymentRequest)
+            ).isInstanceOf(PgServiceRetryException.class)
+                    .hasMessageContaining("PG 서버가 불안정합니다. 잠시후 재시도해주세요.");
+
+            verify(pgClient, times(retryMaxAttemps)).requestPayment(any(), any());
+            verify(pgService, times(1)).requestPaymentRetryFallback(eq(userId), any(), any());
+        }
+    }
+
+    @DisplayName("@CircuitBreaker 테스트")
+    @Nested
+    public class CircuitBreakerTest {
+        @Test
+        @DisplayName("실패율이 기준 이하이면 CircuitBreaker는 닫힌 상태를 유지한다.")
+        void should_not_openCircuitBreaker_when_failureRateIsBelowThreshold() {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+            PgCommonResponse<PgInfo.PaymentResult> successResponse = successResponse();
+
+            // when
+            AtomicBoolean failedOnce = new AtomicBoolean(false);
+
+            when(pgClient.requestPayment(userId, paymentRequest))
+                    .thenAnswer(invocation -> {
+                        if (failedOnce.compareAndSet(false, true)) {
+                            return failResponse();
+                        }
+                        return successResponse;
+                    });
+
+            for (int i = 0; i < 3; i++) {
+                try {
+                    pgService.requestPayment(userId, paymentRequest);
+                } catch (Exception ignored) {
+                }
+            }
+
+            // then
+            CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+            verify(pgClient, atLeast(1)).requestPayment(any(), any());
+        }
+
+        @Test
+        @DisplayName("실패율이 임계값 이상이면 CircuitBreaker는 열린다.")
+        void should_openCircuitBreaker_when_failureRateExceedsThreshold() {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest request = paymentRequest();
+
+            // when
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenThrow(new RetryableBusinessException("fail"));
+
+            for (int i = 0; i < 3; i++) {
+                try {
+                    pgService.requestPayment(userId, request);
+                } catch (Exception ignored) {}
+            }
+
+            // then
+            CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+        }
+
+        @Test
+        @DisplayName("CircuitBreaker가 열린 상태에서는 함수 호출 시, fallback 메서드가 호출된다.")
+        void should_callFallback_whenCircuitIsOpen() {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest request = paymentRequest();
+
+            int fallbackCount = 0;
+
+            // when
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenThrow(new RetryableBusinessException("fail"));
+
+            for (int i = 0; i < 3; i++) {
+                try {
+                    pgService.requestPayment(userId, request);
+                    CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+                    if (pgCircuit.getState().equals(CircuitBreaker.State.OPEN)) {
+                        fallbackCount = fallbackCount + 1;
+                    }
+
+                } catch (Exception ignored) {}
+            }
+
+            Assertions.assertThatThrownBy(
+                            () -> pgService.requestPayment(userId, request)
+                    )
+                    .isInstanceOf(PgServiceRetryException.class)
+                    .hasMessageContaining("PG 서버가 불안정합니다. 잠시후 재시도해주세요.");
+
+
+            //then
+            CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+            verify(pgService, atLeast(fallbackCount)).requestPaymentCircuitFallback(eq(userId), any(), any());
+        }
+
+        @Test
+        @DisplayName("CircuitBreaker가 wait-duration 경과 후 HALF_OPEN 상태로 전환된다.")
+        void should_transitionToHalfOpen_afterWaitDuration() throws InterruptedException {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest request = paymentRequest();
+
+            // when
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenThrow(new RetryableBusinessException("fail"));
+
+            for (int i = 0; i < 5; i++) {
+                try {
+                    pgService.requestPayment(userId, request);
+                } catch (Exception ignored) {
+                }
+            }
+
+            // then
+            CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+            long millis = toMillis(waitDurationInOpenState) + 1000;
+
+
+            Thread.sleep(millis);
+
+            reset(pgClient);
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenReturn(successResponse());
+            pgService.requestPayment(userId, request);
+
+
+            pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.HALF_OPEN);
+        }
+
+        @Test
+        @DisplayName("HALF_OPEN 상태에서 성공 요청이 설정 수치 이상이면 CLOSED 상태로 전환된다.")
+        void should_closeCircuitBreaker_when_halfOpenRequestsSucceed() throws InterruptedException {
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest request = paymentRequest();
+            PgCommonResponse<PgInfo.PaymentResult> success = successResponse();
+
+            // when
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenThrow(new RetryableBusinessException("fail"));
+            for (int i = 0; i < 3; i++) {
+                try {
+                    pgService.requestPayment(userId, request);
+                } catch (Exception ignored) {}
+            }
+
+            long millis = toMillis(waitDurationInOpenState) + 1000;
+            Thread.sleep(millis);
+
+            reset(pgClient);
+            when(pgClient.requestPayment(eq(userId), any()))
+                    .thenReturn(success);
+
+            for (int i = 0; i < permittedNumberOfCallsInHalfOpenState; i++) {
+                pgService.requestPayment(userId, request);
+            }
+
+            // then
+            CircuitBreaker pgCircuit = circuitBreakerRegistry.circuitBreaker("pgCircuit");
+            assertThat(pgCircuit.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+        }
+    }
+
+    @DisplayName("정상 응답")
+    @Nested
+    public class Success {
+
+        @Test
+        @DisplayName("PG서버가 정상응답이면 SUCCESS를 반환한다.")
+        public void returnSuccess_whenPgServerResponseSuccess() throws Exception{
+            // given
+            String userId = "userId";
+            PgCommand.PaymentRequest paymentRequest = paymentRequest();
+
+
+            PgCommonResponse<PgInfo.PaymentResult> response = successResponse();
+
+            given(pgClient.requestPayment(userId, paymentRequest)).willReturn(response);
+
+            // when
+            PgInfo.PaymentResult result = pgService.requestPayment(userId, paymentRequest);
+
+            // then
+            Assertions.assertThat(result).isNotNull();
+            verify(pgClient, times(1)).requestPayment(userId, paymentRequest);
+        }
+
+
+    }
+
+    @DisplayName("실패")
+    @Nested
+    public class Fail {
+
+        @Test
+        @DisplayName("PG서버 응답이 FAIL이면 PgServiceRetryException 발생")
+        void businessFail() {
+            when(pgClient.requestPayment(any(), any()))
+                    .thenReturn(failResponse());
+
+            Assertions.assertThatThrownBy(() ->
+                            pgService.requestPayment("userId", paymentRequest())
+                    ).isInstanceOf(PgServiceRetryException.class)
+                    .hasMessageContaining("PG 서버가 불안정합니다. 잠시후 재시도해주세요.");
+
+            verify(pgClient, times(3)).requestPayment(any(), any());
+        }
+    }
+
+    public static long toMillis(String durationStr) {
+        return Duration.parse(normalize(durationStr)).toMillis();
+    }
+
+    private static String normalize(String input) {
+        input = input.trim().toLowerCase();
+
+        if (input.endsWith("ms")) {
+            double millis = Double.parseDouble(input.replace("ms", ""));
+            double seconds = millis / 1000.0;
+            return "PT" + seconds + "S";
+        } else if (input.endsWith("s")) {
+            return "PT" + input.replace("s", "") + "S";
+        } else if (input.endsWith("m")) {
+            return "PT" + input.replace("m", "") + "M";
+        } else if (input.endsWith("h")) {
+            return "PT" + input.replace("h", "") + "H";
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 단위 형식: " + input);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgServiceTimeoutTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgServiceTimeoutTest.java
@@ -1,0 +1,108 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.infrastructure.pg.PgFeignClient;
+import com.loopers.support.error.PgServiceRetryException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(initializers = PgServiceTimeoutTest.MockServerInitializer.class)
+class PgServiceTimeoutTest {
+
+    static MockWebServer mockWebServer;
+
+    static class MockServerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext context) {
+            TestPropertyValues.of(
+                    "pg.simulator.url=http://localhost:8089"
+            ).applyTo(context.getEnvironment());
+        }
+    }
+
+    @Autowired
+    PgService pgService;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(8089);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Nested
+    @DisplayName("FeignClient ReadTimeout 테스트")
+    public class ReadTimeOut {
+        @Test
+        @DisplayName("ReadTimeout 발생 시 PgServiceRetryException이 발생한다")
+        void should_throwException_when_ReadTimeoutOccurs() {
+            // given
+            mockWebServer.enqueue(new MockResponse()
+                    .setBodyDelay(5, TimeUnit.SECONDS)
+                    .setBody("{\"meta\":{\"result\":\"SUCCESS\"},\"data\":{}}")
+                    .addHeader("Content-Type", "application/json")
+            );
+
+            PgCommand.PaymentRequest request = PgCommand.PaymentRequest.of(
+                    "orderId",
+                    CardType.SAMSUNG,
+                    "1234-5678-9012-3456",
+                    "1000",
+                    "http://localhost:8080/callback"
+            );
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> pgService.requestPayment("user1", request))
+                    .isInstanceOf(PgServiceRetryException.class)
+                    .hasMessageContaining("PG 서버가 불안정합니다");
+        }
+    }
+
+
+    @Autowired
+    PgFeignClient pgFeignClient;
+
+    @Nested
+    @DisplayName("Retry가 없을 경우 FeignClient의 예외 테스트")
+    public class NoRetry {
+        @Test
+        @DisplayName("Feign ReadTimeout은 feign.FeignException 처리된다")
+        void should_throwRetryableException_onReadTimeout() {
+            mockWebServer.enqueue(new MockResponse()
+                    .setBodyDelay(5, TimeUnit.SECONDS)
+                    .setBody("{\"meta\":{\"result\":\"SUCCESS\"},\"data\":{}}")
+                    .addHeader("Content-Type", "application/json")
+            );
+
+            PgCommand.PaymentRequest request = PgCommand.PaymentRequest.of(
+                    "orderId",
+                    CardType.SAMSUNG,
+                    "1234-5678-9012-3456",
+                    "1000",
+                    "http://localhost:8080/callback"
+            );
+
+            Assertions.assertThatThrownBy(() -> pgFeignClient.requestPayment("user1", request))
+                    .isInstanceOf(feign.FeignException.class)
+                    .hasMessageContaining("Read timed out");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgTestConfig.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/pg/PgTestConfig.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.pg;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootTest
+@TestConfiguration
+public class PgTestConfig {
+
+    @Bean
+    PgClient pgClient() {
+        return Mockito.mock(PgClient.class);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderApiE2ETest.java
@@ -17,7 +17,6 @@ import com.loopers.domain.stock.StockRepository;
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.domain.user.UserService;
 import com.loopers.domain.usercoupon.UserCoupon;
 import com.loopers.domain.usercoupon.UserCouponRepository;
 import com.loopers.domain.usercoupon.UserCouponStatus;
@@ -32,7 +31,6 @@ import org.springframework.http.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -128,6 +126,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, 1L))
             );
             orderRequest.setCouponId(couponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -156,6 +155,7 @@ class OrderApiE2ETest {
             orderRequest.setOrderProducts(
                     List.of(new OrderRequest.OrderProduct(productId, 1L))
             );
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -187,6 +187,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, 1L))
             );
             orderRequest.setCouponId(notExistCouponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -225,6 +226,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, 1L))
             );
             orderRequest.setCouponId(inactiveCoupon.getId());
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -257,6 +259,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, illegalStockQuantity))
             );
             orderRequest.setCouponId(couponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -290,6 +293,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, 1L))
             );
             orderRequest.setCouponId(notExistCouponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -330,6 +334,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, illegalStockQuqntity))
             );
             orderRequest.setCouponId(couponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -371,6 +376,7 @@ class OrderApiE2ETest {
                     List.of(new OrderRequest.OrderProduct(productId, originalStockAmount))
             );
             orderRequest.setCouponId(couponId);
+            orderRequest.setPaymentTypeDto(OrderRequest.PaymentTypeDto.POINT);
 
             // when
             ParameterizedTypeReference<ApiResponse<Void>> responseType = new ParameterizedTypeReference<>() {};
@@ -414,7 +420,7 @@ class OrderApiE2ETest {
 
             // 주문 생성
             Long productId = 1L;
-            orderFacade.order(OrderCriteria.Order.of(userId, List.of(
+            orderFacade.order(OrderCriteria.Order.ofPoint(userId, List.of(
                     OrderCriteria.OrderProduct.of(productId, 1L)
             ), coupondId));
 
@@ -481,7 +487,7 @@ class OrderApiE2ETest {
             headers.set("X-USER-ID", userId);
 
             // 주문 생성
-            orderFacade.order(OrderCriteria.Order.of(userId, List.of(
+            orderFacade.order(OrderCriteria.Order.ofPoint(userId, List.of(
                     OrderCriteria.OrderProduct.of(productId, 1L)
             ), coupon.getId()));
 

--- a/apps/commerce-api/src/test/java/com/loopers/scheduler/PgRetrySchedulerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/scheduler/PgRetrySchedulerTest.java
@@ -1,0 +1,100 @@
+package com.loopers.scheduler;
+
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.pg.*;
+import com.loopers.support.error.PgServiceUnavailableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PgRetrySchedulerTest {
+
+    @InjectMocks
+    private PgRetryScheduler scheduler;
+
+    @Mock
+    private PgHistoryService historyService;
+
+    @Mock
+    private OrderService orderService;
+
+    @Mock
+    private PgService pgService;
+
+    @Mock
+    private PaymentService paymentService;
+
+
+    @DisplayName("스케쥴링 단위 테스트")
+    @Nested
+    public class Schedule {
+
+        @Test
+        @DisplayName("스케쥴러에서 모든 실패 결제를 재처리한다.")
+        public void retryAll_whenExistPaymentIsFailed() throws Exception{
+            // given
+            PgHistoryInfo.Failed failed1 = PgHistoryInfo.Failed.of("user1", "order1", "1234-5678-9814-1451", 1000L, CardType.SAMSUNG);
+            PgHistoryInfo.Failed failed2 = PgHistoryInfo.Failed.of("user2", "order2",  "1234-5678-9814-1451", 2000L, CardType.HYUNDAI);
+
+            given(historyService.getPaymentFailedList()).willReturn(List.of(failed1, failed2));
+
+            // when
+            scheduler.retryFailedPgRequests();
+
+            // then
+            verify(pgService, times(1)).requestPayment(eq("user1"), any());
+            verify(pgService, times(1)).requestPayment(eq("user2"), any());
+            verify(paymentService, times(2)).pay(any());
+            verify(orderService, times(2)).complete(any());
+            verify(historyService, times(2)).complete(any());
+            verify(historyService, never()).touch(any());
+        }
+
+        @Test
+        @DisplayName("일부 재처리 실패 케이스가 존재할 경우, touch를 호출해 업데이트 시간을 변경한다.")
+        void callTouch_whenExistRetryFailed() {
+            // given
+            PgHistoryInfo.Failed failed1 = PgHistoryInfo.Failed.of("user1", "order1", "1234-5678-9814-1451", 1000L, CardType.SAMSUNG);
+            PgHistoryInfo.Failed failed2 = PgHistoryInfo.Failed.of("user2", "order2", "1234-5678-9814-1451", 2000L, CardType.HYUNDAI);
+
+            given(historyService.getPaymentFailedList()).willReturn(List.of(failed1, failed2));
+
+            PgInfo.PaymentResult mockResult = mock(PgInfo.PaymentResult.class);
+            given(pgService.requestPayment(eq("user1"), any(PgCommand.PaymentRequest.class)))
+                    .willReturn(mockResult);
+
+            willThrow(new PgServiceUnavailableException("retry failed"))
+                    .given(pgService)
+                    .requestPayment(eq("user2"), any(PgCommand.PaymentRequest.class));
+
+            // when
+            scheduler.retryFailedPgRequests();
+
+            // then
+            verify(pgService, times(1)).requestPayment(eq("user1"), any());
+            verify(pgService, times(1)).requestPayment(eq("user2"), any());
+
+            verify(historyService, times(1)).complete("order1");
+            verify(historyService, times(1)).touch(List.of("order2"));
+        }
+
+    }
+
+
+
+
+
+}

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardTypeDto": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    val kotlinVersion = "2.0.20"
+
+    id("org.jetbrains.kotlin.jvm") version(kotlinVersion)
+    id("org.jetbrains.kotlin.kapt") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.spring") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.jpa") version(kotlinVersion)
+}
+
+kotlin {
+    compilerOptions {
+        jvmToolchain(21)
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.*
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,136 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "commerce-api": "http://localhost:8080"
+    "commerce-api": "http://localhost:8080",
+    "pg-simulator": "http://localhost:8082"
   }
 }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,0 +1,41 @@
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "550e8400-e29b-41d4-a716-446655440000",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/payment/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250822:TR:86594e
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+
+
+### RESPONSE
+{
+  "meta": {
+    "result": "SUCCESS"
+  },
+  "data": {
+    "transactionKey": "20250818:TR:e2ad1b",
+    "status": "PENDING"
+  }
+}
+
+{
+  "meta": {
+    "result": "FAIL",
+    "errorCode": "Internal Server Error",
+    "message": "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요."
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "loopers-e-commerce"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
     ":supports:jackson",


### PR DESCRIPTION
## 📌 Summary
6주차는 아래의 내용을 중점으로 진행하였습니다.
- openFeigin을 이용한 외부 시스템 연동 
- Resilience를 이용한 retry, circuit breaker 적용 

설정 값들의 수치(기준값)보다는 설정 들이 실제로 어떻게 동작되는지에 대해서 테스트 코드를 통해 확인하고 검증해보았습니다.
카드 결제가 추가되면서 기존 DTO에 카드 결제 항목을 추가하는 방향으로 진행했지만 여유가 된다면 좀더 추상화해서 구조적으로 확장성
있게 가져갈수있을거라고 생각했습니다.(진행하진 못했습니다 ㅜㅜ)

## 💬 Review Points
### 1. Resilience 테스트 시 Context 오염 문제
- **배경**  
  - Mock을 활용해 Resilience4j 설정값이 정상적으로 반영되는지 통합 테스트를 작성했습니다.  
  - 테스트 실행 과정에서 `CircuitBreaker`와 `Retry` 카운트가 서로 영향을 주며 오염되는 문제가 발생했습니다.
- **시도한 해결책**  
  - `@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)` -> 느림
  - `cbRegistry.getAllCircuitBreakers().forEach(CircuitBreaker::reset)`  
  - `retryRegistry.getAllRetries().forEach(Retry::reset)`  
  - 위 방식으로 매 테스트마다 초기화를 진행했으나, 테스트 속도가 크게 느려졌습니다. -> 속도는 개선했습니다!
- **질문/논의 포인트**  
  - 실무에서는 Resilience 설정 검증을 어떤 수준까지 테스트하시는지 궁금합니다.
  - 실무에서 테스트 한다면 오염문제를 해결하기 위해 어떤 방법을 사용하는지도 궁금합니다.

---

### 2. Retry와 CircuitBreaker 동작 순서/조합
- **관찰된 현상**  
  - Retry에서 발생시킨 예외가 CircuitBreaker에 의해 먼저 처리되어, Retry 동작이 기대와 달라지는 케이스를 확인했습니다.  
  - 공식 문서 기준 순서:  
    ```
    Retry ( CircuitBreaker ( RateLimiter ( TimeLimiter ( Bulkhead ( Function ) ) ) ) )
    ```
    → 즉, CircuitBreaker에서 예외를 던져야 Retry가 동작.  
  - Retry와 CircuitBreaker를 동시에 걸었을 때, 재시도로 인해 CircuitBreaker의 실패 카운트도 예측과 다르게 집계되는 상황 발생.
- **질문/논의 포인트**  
  - 실무에서도 `Retry`와 `CircuitBreaker`를 함께 적용하는 케이스가 많은지,  
  - 아니면 보통은 기능별로 선택적으로 적용하는지(예: 외부 연동 = CircuitBreaker, 내부 불안정 로직 = Retry) 궁금합니다.  

---

### 3. 스케줄러 패키지 구조
- **배경**  
  - 배치성 작업/스케줄러를 구현할 때 패키지 위치를 어디에 두어야 할지 고민입니다.
- **질문/논의 포인트**  
  - 일반적으로 `scheduler` 같은 패키지를 별도로 분리하는지,  
  - 아니면 `application` / `infrastructure` 레이어 하위로 포함시키는지에 대한 팀 내 가이드라인이 있는지 궁금합니다.

---

### 4. 외부 연동 API 테스트
- **배경**  
  - FeignClient의 ReadTimeOut을 테스트 해보기 위해서 MockWebServer를 사용해보았습니다.
  - mockWebServer URL을 동적으로 추가하려고 시도했지만, 실패했고, 결국 하드코딩으로 추가하였습니다.
- **질문/논의 포인트**  
  - FeignCliet의 ReadTimeOut테스트를 위해 사용했지만 MockWebserver에 동적 URL 지정만 가능하다면 외부연동 테스트도 가능하다고 생각했습니다. FeignClient를 이미 만들어놓고 사용하니 동적 URL 지정이 불가능했는데, 실무에서 OpenAPI 연동 테스트는 어떻게 진행하는걸까요?

---

## Reviewer에게 드리는 질문
1. Resilience4j 테스트에서 **Context 초기화 문제**를 실무에서는 어떻게 다루는지? (Mock 단위테스트 위주인지, 통합테스트에서 상태검증까지 하시는지)  
2. **Retry + CircuitBreaker** 조합을 실제 운영 코드에서 어떻게 활용하는지? (적용 사례, 주의할 점)  
3. **Scheduler 패키지 구조**에 대한 선호나 팀 내 합의된 규칙이 있는지?
4. **외부연동API테스트** 방법이 있을까요? 


## ✅ Checklist

### **⚡ PG 연동 대응**

- [ ]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [ ]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [ ]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [ ]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [ ]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [ ]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [ ]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [ ]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.

## 📎 References
공식문서 : https://resilience4j.readme.io/docs/getting-started-3#annotation-order
테스트격리 : https://mincanit.tistory.com/70