### PR TITLE
[round-9] Ranking System

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -8,6 +8,8 @@ import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductCommand;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.rankings.RankingsInfo;
+import com.loopers.domain.rankings.RankingsService;
 import com.loopers.domain.stock.StockInfo;
 import com.loopers.domain.stock.StockService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Component
@@ -29,6 +32,8 @@ public class ProductFacade {
     private final StockService stockService;
 
     private final LikeService likeService;
+
+    private final RankingsService rankingsService;
 
     public List<ProductResult.Product> getProducts(ProductCriteria.ProductRequest request) {
         List<ProductInfo.ProductQuery> products = productService.getProducts(ProductCommand.Search.of(
@@ -55,12 +60,13 @@ public class ProductFacade {
                             ProductResult.Like.of(likedProductIds.contains(product.getProductId()), product.getLikes())
                     );
                 }).toList();
-
     }
 
     public ProductResult.ProductDetail getProductDetail(ProductCriteria.ProductDetailRequest request) {
         ProductInfo.ProductDetail findProductDetail
-                = productService.getProductDetail(request.getProductId());
+                = productService.getProduct(request.getProductId());
+
+        Optional<RankingsInfo.Ranking> ranking = rankingsService.getRanking(request.getProductId());
 
         BrandInfo.Brand findBrand
                 = brandService.getBrand(BrandCommand.Search.of(findProductDetail.getBrandId()));
@@ -76,7 +82,8 @@ public class ProductFacade {
                 findProductDetail.getPrice(),
                 ProductResult.Brand.of(findBrand.getName()),
                 ProductResult.Like.of(liked, productLikeCount),
-                ProductResult.Stock.of(stock.getQuantity())
+                ProductResult.Stock.of(stock.getQuantity()),
+                ranking.map(RankingsInfo.Ranking::getRank).orElse(null)
         );
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -47,21 +47,25 @@ public class ProductResult {
         private Like like;
         private Stock stock;
 
-        private ProductDetail(String name, Long price, Brand brand, Like like, Stock stock) {
+        private Long ranking;
+
+        private ProductDetail(String name, Long price, Brand brand, Like like, Stock stock, Long ranking) {
             this.name = name;
             this.price = price;
             this.brand = brand;
             this.like = like;
             this.stock = stock;
+            this.ranking = ranking;
         }
 
-       public static ProductDetail of(String name, Long price, Brand brand, Like like, Stock stock) {
+       public static ProductDetail of(String name, Long price, Brand brand, Like like, Stock stock, Long ranking) {
             return ProductDetail.builder()
                     .name(name)
                     .price(price)
                     .brand(brand)
                     .like(like)
                     .stock(stock)
+                    .ranking(ranking)
                     .build();
        }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsCriteria.java
@@ -1,0 +1,38 @@
+package com.loopers.application.rankings;
+
+import com.loopers.domain.rankings.RankType;
+import com.loopers.domain.rankings.RankingsCommand;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class RankingsCriteria {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class PageInfo {
+        private String userId;
+        private LocalDate date;
+        private Long page;
+        private Long size;
+        private String type;
+
+        public static PageInfo of(String userId, LocalDate date, Long page, Long size, String type) {
+            return PageInfo.builder()
+                    .userId(userId)
+                    .date(date)
+                    .page(page)
+                    .size(size)
+                    .type(type)
+                    .build();
+        }
+
+        public RankingsCommand.PageInfo toPageInfo() {
+            return RankingsCommand.PageInfo.of(date, page, size, RankType.from(type));
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsFacade.java
@@ -1,0 +1,40 @@
+package com.loopers.application.rankings;
+
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.rankings.RankingsInfo;
+import com.loopers.domain.rankings.RankingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RankingsFacade {
+
+    private final RankingsService rankingsService;
+
+    private final LikeService likeService;
+
+    @Transactional
+    public List<RankingsResult.Rankings> getRankings(RankingsCriteria.PageInfo page) {
+        List<RankingsInfo.ProductSummary> productByRank = rankingsService.getProductByRank(page.toPageInfo());
+
+        List<Long> likedProductIdsByUserId = likeService.getLikedProductIdsByUserId(page.getUserId());
+
+        return productByRank.stream()
+                .map(p -> RankingsResult.Rankings.of(
+                                p.getProduct().getProductName(),
+                                p.getProduct().getBrandName(),
+                                p.getProduct().getPrice(),
+                                p.getRanking().getRank(),
+                                p.getRanking().getScore(),
+                                likedProductIdsByUserId.contains(p.getProduct().getProductId()),
+                                p.getProduct().getLikeCount()
+
+                        )
+                ).toList();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/rankings/RankingsResult.java
@@ -1,0 +1,31 @@
+package com.loopers.application.rankings;
+
+import lombok.*;
+
+public class RankingsResult {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Rankings {
+        private String productName;
+        private String brandName;
+        private Long price;
+        private Long rank;
+        private Double score;
+        private Boolean isLiked;
+        private Long likeCount;
+
+        public static Rankings of(String productName, String brandName, Long price, Long rank, Double score, Boolean isLiked, Long likeCount) {
+            return Rankings.builder()
+                    .productName(productName)
+                    .brandName(brandName)
+                    .price(price)
+                    .rank(rank)
+                    .score(score)
+                    .isLiked(isLiked)
+                    .likeCount(likeCount)
+                    .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -19,4 +19,6 @@ public interface LikeRepository {
 
     Set<Long> findLikedProductIds(String userId, List<Long> productIds);
 
+    List<Long> findLikedProductIdsByUserId(String userId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -56,4 +56,8 @@ public class LikeService {
                         )
                 ).toList();
     }
+
+    public List<Long> getLikedProductIdsByUserId(String userId) {
+        return likeRepository.findLikedProductIdsByUserId(userId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEvent.java
@@ -2,6 +2,8 @@ package com.loopers.domain.order;
 
 import lombok.*;
 
+import java.util.List;
+
 public class OrderEvent {
 
     @Getter
@@ -13,15 +15,39 @@ public class OrderEvent {
         private Long orderId;
         private String orderNumber;
         private Long amount;
+        private List<OrderProduct> orderProducts;
 
-        public static Completed of(Long orderId, String orderNumber, Long amount) {
+        public static Completed of(String userId, Long orderId, String orderNumber, Long amount, List<OrderProduct> orderProducts) {
             return Completed
                     .builder()
+                    .userId(userId)
                     .orderId(orderId)
                     .orderNumber(orderNumber)
                     .amount(amount)
+                    .orderProducts(orderProducts)
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    public static class OrderProduct {
+        private Long productId;
+        private Long quantity;
+
+        private OrderProduct(Long productId, Long quantity) {
+            this.productId = productId;
+            this.quantity = quantity;
+        }
+
+        public static OrderProduct of(Long productId, Long quantity) {
+            return OrderProduct.builder()
+                    .productId(productId)
+                    .quantity(quantity)
+                    .build();
+        }
+    }
+
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -33,7 +33,12 @@ public class OrderService {
 
         Order save = orderRepository.save(order);
 
-        orderEventPublisher.publish(OrderEvent.Completed.of(order.getId(), order.getOrderNumber(), order.calculateFinalPrice()));
+
+        orderEventPublisher.publish(OrderEvent.Completed.of(command.getUserId(), order.getId(), order.getOrderNumber(), order.calculateFinalPrice(),
+                command.orderProducts.getOrderProducts().stream()
+                        .map(op -> OrderEvent.OrderProduct.of(op.getProductId(), op.getQuantity())).toList()
+                )
+        );
 
         traceEventPublisher.publish(TraceOrderEvent.OrderCompleted.of(
                 command.getUserId(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
@@ -3,7 +3,6 @@ package com.loopers.domain.product;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,9 +1,15 @@
 package com.loopers.domain.product;
 
+import com.loopers.common.kafka.event.EventMessage;
+import com.loopers.common.kafka.event.EventType;
+import com.loopers.common.kafka.event.pageview.PageViewOutEvent;
+import com.loopers.common.kafka.topic.Topics;
+import com.loopers.domain.sender.MessageSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -12,11 +18,28 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
+    private final MessageSender messageSender;
+
     public List<ProductInfo.ProductQuery> getProducts(ProductCommand.Search command) {
         return productRepository.search(command);
     }
 
     public ProductInfo.ProductDetail getProductDetail(Long productId) {
+        Product product = productRepository.findById(productId);
+        return ProductInfo.ProductDetail.of(product.getName(), product.getPrice(), product.getBrandId());
+    }
+
+    public ProductInfo.ProductDetail getProduct(Long productId) {
+        messageSender.send(Topics.PAGE_VIEW, productId.toString(),
+                EventMessage.<PageViewOutEvent.Viewed>builder()
+                        .eventType(EventType.PAGE_VIEWED)
+                        .version("v1")
+                        .payload(PageViewOutEvent.Viewed.of(
+                                productId,
+                                LocalDateTime.now()))
+                        .build()
+        );
+
         Product product = productRepository.findById(productId);
         return ProductInfo.ProductDetail.of(product.getName(), product.getPrice(), product.getBrandId());
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankType.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.rankings;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RankType {
+
+    LIKE_RANK("like"),
+    SALES_RANK("sales"),
+    PV_RANK("pv"),
+    ALL_RANK("all")
+    ;
+
+    public static RankType from(String input) {
+        for (RankType type : RankType.values()) {
+            if (type.type.equalsIgnoreCase(input)) {
+                return type;
+            }
+        }
+        return ALL_RANK;
+    }
+
+    private final String type;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsCommand.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.rankings;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+public class RankingsCommand {
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class PageInfo {
+        private LocalDate date;
+        private Long page;
+        private Long size;
+        private RankType type;
+
+        public static PageInfo of(LocalDate date, Long page, Long size, RankType type) {
+            return PageInfo.builder()
+                    .date(date)
+                    .page(page)
+                    .size(size)
+                    .type(type)
+                    .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsInfo.java
@@ -1,0 +1,62 @@
+package com.loopers.domain.rankings;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class RankingsInfo {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ProductSummary {
+        private Product product;
+        private Ranking ranking;
+
+        public static ProductSummary of(Product product, Ranking ranking) {
+            return ProductSummary.builder()
+                    .product(product)
+                    .ranking(ranking)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Product {
+        private Long productId;
+        private String productName;
+        private Long price;
+        private String brandName;
+        private Long likeCount;
+
+        public static Product of(Long productId, String productName, Long price, String brandName, Long likeCount) {
+            return Product.builder()
+                    .productId(productId)
+                    .productName(productName)
+                    .price(price)
+                    .brandName(brandName)
+                    .likeCount(likeCount)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Ranking {
+        private Long productId;
+        private Long rank;
+        private Double score;
+
+        public static Ranking of(Long productId, Long rank, Double score) {
+            return Ranking.builder()
+                    .productId(productId)
+                    .rank(rank)
+                    .score(score)
+                    .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.rankings;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RankingsRepository {
+    List<RankingsInfo.Ranking> getProductsByRank(RankingsCommand.PageInfo page);
+
+    List<RankingsInfo.Product> getProductsByIds(List<Long> productIds);
+
+    Optional<RankingsInfo.Ranking> getProductRanking(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/rankings/RankingsService.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.rankings;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RankingsService {
+
+    private final RankingsRepository rankingsRepository;
+
+    public List<RankingsInfo.ProductSummary> getProductByRank(RankingsCommand.PageInfo page) {
+        List<RankingsInfo.Ranking> productsByRank = rankingsRepository.getProductsByRank(page);
+
+        List<RankingsInfo.Product> productsByIds = rankingsRepository.getProductsByIds(productsByRank.stream().map(RankingsInfo.Ranking::getProductId).toList());
+
+        return productsByRank.stream()
+                .map(ranking -> {
+                    RankingsInfo.Product product = productsByIds.stream()
+                            .filter(p -> p.getProductId().equals(ranking.getProductId()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("Product not found: " + ranking.getProductId()));
+                    return RankingsInfo.ProductSummary.of(
+                            product,
+                            ranking
+                    );
+                })
+                .toList();
+    }
+
+    public Optional<RankingsInfo.Ranking> getRanking(Long productId) {
+         return rankingsRepository.getProductRanking(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -54,4 +54,12 @@ public class LikeRepositoryImpl implements LikeRepository {
     public Set<Long> findLikedProductIds(String userId, List<Long> productIds) {
         return likeJpaRepository.findLikedProductIds(userId, productIds);
     }
+
+    @Override
+    public List<Long> findLikedProductIdsByUserId(String userId) {
+        return likeJpaRepository.findAllByUserId(userId)
+                .stream()
+                .map(Like::getProductId)
+                .toList();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsCacheRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.rankings;
+
+import com.loopers.domain.rankings.RankingsInfo;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RankingsCacheRepository {
+    List<RankingsInfo.Ranking> getProductRankings(String type, LocalDate date, Integer size, Integer page);
+
+    RankingsInfo.Ranking getProductRanking(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.rankings;
+
+import com.loopers.domain.rankings.RankingsInfo;
+
+import java.util.List;
+
+public interface RankingsQueryDslRepository {
+    List<RankingsInfo.Product> search(List<Long> productIds);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsQueryDslRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.loopers.infrastructure.rankings;
+
+import com.loopers.domain.brand.QBrand;
+import com.loopers.domain.product.QProduct;
+import com.loopers.domain.rankings.RankingsInfo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.loopers.domain.brand.QBrand.*;
+import static com.loopers.domain.product.QProduct.*;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingsQueryDslRepositoryImpl implements RankingsQueryDslRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RankingsInfo.Product> search(List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        RankingsInfo.Product.class,
+                        product.id,
+                        product.name,
+                        product.price,
+                        brand.name,
+                        product.likeCount
+                ))
+                .from(product)
+                .join(brand).on(product.brandId.eq(brand.id))
+                .where(product.id.in(productIds))
+                .fetch();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsRedisRepository.java
@@ -1,0 +1,68 @@
+package com.loopers.infrastructure.rankings;
+
+import com.loopers.domain.rankings.RankingsInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingsRedisRepository implements RankingsCacheRepository{
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final DateTimeFormatter keyFormat = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private String zkey(String type, LocalDate date) {
+        String ymd = keyFormat.format(date);
+        return switch (normalizeType(type)) {
+            case "like"  -> "rank:like:" + ymd;
+            case "sales" -> "rank:sales:" + ymd;
+            case "pv"    -> "rank:pv:" + ymd;
+            default      -> "rank:all:" + ymd;
+        };
+    }
+
+
+    private String normalizeType(String type) {
+        if (type == null) return "all";
+        return switch (type.toLowerCase(Locale.ROOT)) {
+            case "like", "sales", "pv", "all" -> type.toLowerCase(Locale.ROOT);
+            default -> "all";
+        };
+     }
+
+     @Override
+    public List<RankingsInfo.Ranking> getProductRankings(String type, LocalDate date, Integer size, Integer page) {
+        String key = zkey(type, date);
+        int offset = (page - 1) * size;
+        int end = offset + size - 1;
+        AtomicLong rank = new AtomicLong(offset + 1);
+        return redisTemplate.opsForZSet().reverseRangeWithScores(key, offset, end)
+                .stream()
+                .map(v ->
+                        RankingsInfo.Ranking.of(Long.valueOf(v.getValue()), rank.getAndIncrement(), v.getScore()))
+                .toList();
+    }
+
+    @Override
+    public RankingsInfo.Ranking getProductRanking(Long productId) {
+        String key = zkey("all", LocalDate.now());
+        Double score = redisTemplate.opsForZSet().score(key, String.valueOf(productId));
+        if (score == null) {
+            return null;
+        }
+        Long rank = redisTemplate.opsForZSet().reverseRank(key, String.valueOf(productId));
+        if (rank == null) {
+            return null;
+        }
+        return RankingsInfo.Ranking.of(productId, rank + 1, score);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/rankings/RankingsRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.loopers.infrastructure.rankings;
+
+import com.loopers.domain.rankings.RankingsCommand;
+import com.loopers.domain.rankings.RankingsInfo;
+import com.loopers.domain.rankings.RankingsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingsRepositoryImpl implements RankingsRepository {
+
+    private final RankingsCacheRepository rankingsCacheRepository;
+
+    private final RankingsQueryDslRepository rankingsQueryDslRepository;
+
+    @Override
+    public List<RankingsInfo.Ranking> getProductsByRank(RankingsCommand.PageInfo page) {
+        return rankingsCacheRepository.getProductRankings(
+                page.getType().name().toLowerCase(),
+                page.getDate(),
+                page.getSize().intValue(),
+                page.getPage().intValue()
+        );
+    }
+
+    public List<RankingsInfo.Product> getProductsByIds(List<Long> productIds) {
+        return rankingsQueryDslRepository.search(productIds);
+    }
+
+    @Override
+    public Optional<RankingsInfo.Ranking> getProductRanking(Long productId) {
+        return Optional.ofNullable(rankingsCacheRepository.getProductRanking(productId));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/external/ExternalDataPlatformListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/external/ExternalDataPlatformListener.java
@@ -1,12 +1,19 @@
 package com.loopers.interfaces.api.event.external;
 
+import com.loopers.common.kafka.event.EventMessage;
+import com.loopers.common.kafka.event.EventType;
+import com.loopers.common.kafka.event.order.OrderOutEvent;
+import com.loopers.common.kafka.topic.Topics;
 import com.loopers.domain.external.ExternalDataService;
 import com.loopers.domain.external.OrderResultPayload;
 import com.loopers.domain.order.OrderEvent;
+import com.loopers.domain.sender.MessageSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -14,9 +21,30 @@ public class ExternalDataPlatformListener {
 
     private final ExternalDataService externalDataService;
 
+    private final MessageSender messageSender;
+
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(OrderEvent.Completed event) {
         externalDataService.send("ORDER", OrderResultPayload.of(event.getOrderId(), event.getOrderNumber(), event.getAmount()));
+
+        event.getOrderProducts().stream().forEach(
+                orderProduct -> {
+                    messageSender.send(Topics.ORDER,
+                            event.getUserId().toString(),
+                            EventMessage.<OrderOutEvent.Order>builder()
+                                    .eventType(EventType.ORDER_COMPLETED)
+                                    .version("v1")
+                                    .payload(OrderOutEvent.Order.of(
+                                            event.getUserId(),
+                                            orderProduct.getProductId(),
+                                            event.getOrderId(),
+                                            event.getOrderNumber(),
+                                            orderProduct.getQuantity(),
+                                            LocalDateTime.now()))
+                                    .build()
+                    );
+                }
+        );
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductResponse.java
@@ -53,32 +53,31 @@ public class ProductResponse {
     @Getter
     @Builder
     public static class ProductDetail {
-
         private String name;
         private Long price;
-
         private Brand brand;
-
         private Like like;
-
         private Stock stock;
+        private Long rank;
 
-        private ProductDetail(String name, Long price, Brand brand, Like like, Stock stock) {
+        private ProductDetail(String name, Long price, Brand brand, Like like, Stock stock, Long rank) {
             this.name = name;
             this.price = price;
             this.brand = brand;
             this.like = like;
             this.stock = stock;
+            this.rank = rank;
         }
 
 
-        public static ProductDetail of(String name, Long price, Brand brand, Like like, Stock stock) {
+        public static ProductDetail of(String name, Long price, Brand brand, Like like, Stock stock, Long rank) {
             return ProductDetail.builder()
                     .name(name)
                     .price(price)
                     .brand(brand)
                     .like(like)
                     .stock(stock)
+                    .rank(rank)
                     .build();
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -25,7 +25,8 @@ public class ProductV1Controller implements ProductV1ApiSpec {
                         productDetail.getPrice(),
                         ProductResponse.Brand.of(productDetail.getBrand().getName()),
                         ProductResponse.Like.of(productDetail.getLike().getLiked(), productDetail.getLike().getCount()),
-                        ProductResponse.Stock.of(productDetail.getStock().getQuantity())
+                        ProductResponse.Stock.of(productDetail.getStock().getQuantity()),
+                        productDetail.getRanking()
                 )
         );
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsResponse.java
@@ -1,0 +1,50 @@
+package com.loopers.interfaces.api.rankings;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class RankingsResponse {
+
+    @Getter
+    @Builder
+    public static class Rankings {
+        private List<Product> rankings;
+
+        private Rankings(List<Product> rankings) {
+            this.rankings = rankings;
+        }
+
+        public static Rankings of(List<Product> rankings) {
+            return Rankings.builder().rankings(rankings).build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Product {
+        private String productName;
+        private Long price;
+        private String brandName;
+        private Boolean isLiked;
+        private Long likeCount;
+        private Long rank;
+
+        public static Product of(String productName, Long price, String brandName, Boolean isLiked, Long likeCount, Long rank) {
+            return Product.builder()
+                    .productName(productName)
+                    .price(price)
+                    .brandName(brandName)
+                    .isLiked(isLiked)
+                    .likeCount(likeCount)
+                    .rank(rank)
+                    .build();
+        }
+
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsV1ApiSpec.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.rankings;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.time.LocalDate;
+
+public interface RankingsV1ApiSpec {
+
+    @Operation(
+            summary = "랭킹 상품 목록 조회",
+            description = "랭킹 상품 목록을 조회합니다."
+    )
+    ApiResponse<RankingsResponse.Rankings> getRankings(
+                                                        String userId,
+                                                        LocalDate date,
+                                                        Long size,
+                                                        Long page
+                                                        );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/rankings/RankingsV1Controller.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.api.rankings;
+
+import com.loopers.application.rankings.RankingsCriteria;
+import com.loopers.application.rankings.RankingsFacade;
+import com.loopers.application.rankings.RankingsResult;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/rankings")
+@RequiredArgsConstructor
+public class RankingsV1Controller implements RankingsV1ApiSpec {
+
+    private final RankingsFacade rankingFacade;
+
+    @Override
+    @GetMapping
+    public ApiResponse<RankingsResponse.Rankings> getRankings(@RequestHeader(value = "X-USER-ID", required = false) String userId,
+                                                              @RequestParam LocalDate date,
+                                                              @RequestParam(defaultValue = "20") Long size,
+                                                              @RequestParam(defaultValue = "1") Long page
+                                                              ) {
+
+        List<RankingsResult.Rankings> rankings = rankingFacade.getRankings(RankingsCriteria.PageInfo.of(userId, date, page, size, "all"));
+
+        return ApiResponse.success(
+                RankingsResponse.Rankings.of(
+                        rankings.stream().map(ranking ->
+                                RankingsResponse.Product.of(
+                                        ranking.getProductName(),
+                                        ranking.getPrice(),
+                                        ranking.getBrandName(),
+                                        ranking.getIsLiked(),
+                                        ranking.getLikeCount(),
+                                        ranking.getRank()
+                                )
+                        ).toList()
+                )
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -5,20 +5,19 @@ import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.Product;
-import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.sender.MessageSender;
 import com.loopers.domain.stock.Stock;
 import com.loopers.domain.stock.StockRepository;
 import com.loopers.utils.DatabaseCleanUp;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -47,6 +46,9 @@ class ProductFacadeIntegrationTest {
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
+
+    @MockBean
+    private MessageSender messageSender;
 
     @AfterEach
     void tearDown() {

--- a/apps/commerce-api/src/test/java/com/loopers/application/rankings/RankingsFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/rankings/RankingsFacadeIntegrationTest.java
@@ -1,0 +1,175 @@
+package com.loopers.application.rankings;
+
+import com.loopers.fixture.rankings.RankingFixture;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.rankings.RankType;
+import com.loopers.domain.stock.StockRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingsFacadeIntegrationTest {
+
+    @Autowired
+    private RankingsFacade rankingsFacade;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    private RankingFixture fx;
+
+    @BeforeEach
+    void setUp() {
+        fx = new RankingFixture(
+                brandRepository,
+                productRepository,
+                stockRepository,
+                likeRepository,
+                stringRedisTemplate,
+                this::todayAllKey
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+        redisCleanUp.truncateAll();
+    }
+
+    private String todayAllKey() {
+        return "rank:all:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now());
+    }
+
+
+    @DisplayName("랭킹 페이지 조회")
+    @Nested
+    public class GetRankingPage {
+
+        @Test
+        @DisplayName("상위 점수 순으로 페이징된 랭킹과 찜 여부가 매핑되어 반환된다 (size=2, page=1)")
+        void returnsPagedRankingsWithLikedFlag_whenValidRequest() {
+            // given
+            String userId = "hoyo";
+            Brand brand = fx.brand("B");
+
+            Product p1 = fx.product(brand, "P1", 1000L);
+            Product p2 = fx.product(brand, "P2", 2000L);
+            Product p3 = fx.product(brand, "P3", 3000L);
+
+            fx.stock(p1, 100L);
+            fx.stock(p2, 100L);
+            fx.stock(p3, 100L);
+
+            fx.like(userId, p2);
+
+            fx.zadd(Map.of(
+                    p1, 30.0,
+                    p2, 40.0,
+                    p3, 50.0
+            ));
+
+            RankingsCriteria.PageInfo criteria = RankingsCriteria.PageInfo.of(
+                    userId, LocalDate.now(), 1L, 2L, RankType.ALL_RANK.getType()
+            );
+
+            // when
+            List<RankingsResult.Rankings> result = rankingsFacade.getRankings(criteria);
+
+            // then
+            assertThat(result).hasSize(2);
+
+            RankingsResult.Rankings r1 = result.get(0);
+            assertThat(r1.getProductName()).isEqualTo("P3");
+            assertThat(r1.getBrandName()).isEqualTo("B");
+            assertThat(r1.getPrice()).isEqualTo(3000L);
+            assertThat(r1.getRank()).isEqualTo(1L);
+            assertThat(r1.getScore()).isEqualTo(50.0);
+            assertThat(r1.getIsLiked()).isFalse();
+
+            RankingsResult.Rankings r2 = result.get(1);
+            assertThat(r2.getProductName()).isEqualTo("P2");
+            assertThat(r2.getBrandName()).isEqualTo("B");
+            assertThat(r2.getPrice()).isEqualTo(2000L);
+            assertThat(r2.getRank()).isEqualTo(2L);
+            assertThat(r2.getScore()).isEqualTo(40.0);
+            assertThat(r2.getIsLiked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("페이지네이션: size=2, page=2 요청 시 3위와 4위 상품이 순서대로 반환되고 찜 여부도 반영된다")
+        void returnsThirdAndFourthRankedProducts_onSecondPage_withLikedFlag() {
+            // given
+            String userId = "hoyo-2";
+            Brand brand = fx.brand("B");
+
+            Product p1 = fx.product(brand, "P1", 1000L);
+            Product p2 = fx.product(brand, "P2", 2000L);
+            Product p3 = fx.product(brand, "P3", 3000L);
+            Product p4 = fx.product(brand, "P4", 4000L);
+            Product p5 = fx.product(brand, "P5", 5000L);
+
+            fx.stock(p1, 100L); fx.stock(p2, 100L); fx.stock(p3, 100L);
+            fx.stock(p4, 100L); fx.stock(p5, 100L);
+
+            fx.zadd(Map.of(p1, 50.0, p2, 60.0, p3, 70.0, p4, 80.0, p5, 90.0));
+
+            fx.like(userId, p3);
+
+            RankingsCriteria.PageInfo criteria = RankingsCriteria.PageInfo.of(
+                    userId, LocalDate.now(), 2L, 2L, RankType.ALL_RANK.getType()
+            );
+
+            // when
+            List<RankingsResult.Rankings> result = rankingsFacade.getRankings(criteria);
+
+            assertThat(result).hasSize(2);
+
+            RankingsResult.Rankings r1 = result.get(0);
+            assertThat(r1.getProductName()).isEqualTo("P3");
+            assertThat(r1.getRank()).isEqualTo(3L);
+            assertThat(r1.getScore()).isEqualTo(70.0);
+            assertThat(r1.getIsLiked()).isTrue();
+
+            RankingsResult.Rankings r2 = result.get(1);
+            assertThat(r2.getProductName()).isEqualTo("P2");
+            assertThat(r2.getRank()).isEqualTo(4L);
+            assertThat(r2.getScore()).isEqualTo(60.0);
+            assertThat(r2.getIsLiked()).isFalse();
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/rankings/RankingsServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/rankings/RankingsServiceIntegrationTest.java
@@ -1,0 +1,231 @@
+package com.loopers.domain.rankings;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RankingsServiceIntegrationTest {
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private RankingsService rankingsService;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+        databaseCleanUp.truncateAllTables();
+    }
+
+
+
+    private String buildTodayAllKey() {
+        return "rank:all:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now());
+    }
+
+    private List<Long> addBrandAndProduct() {
+        Brand brand = brandRepository.save(Brand.create("Test Brand", "Test Description"));
+
+        List<Long> productIds = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Product p = productRepository.save(Product.create(
+                    brand.getId(),
+                    "Product " + i,
+                    1000L + i * 100
+            ));
+
+            productIds.add(p.getId());
+
+        }
+
+        return productIds;
+    }
+
+    @DisplayName("상품 랭킹 조회")
+    @Nested
+    public class GetProductRanking {
+
+        @Test
+        @DisplayName("제품이 랭킹에 존재한다면 랭킹 정보를 반환한다.")
+        void returnsRanking_whenProductIsExistRanking() {
+            // given
+            String key = buildTodayAllKey();
+            Long productId = 101L;
+
+            stringRedisTemplate.opsForZSet().add(key, productId.toString(), 12.5);
+
+            // when
+            Optional<RankingsInfo.Ranking> result = rankingsService.getRanking(productId);
+
+            // then
+            assertThat(result).isPresent();
+            RankingsInfo.Ranking ranking = result.get();
+            assertThat(ranking.getProductId()).isEqualTo(productId);
+            assertThat(ranking.getScore()).isEqualTo(12.5);
+            assertThat(ranking.getRank()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("제품이 랭킹에 존재하지 않는다면 Optional.empty를 반환한다.")
+        public void returnEmpty_whenProductIsNotExistRanking() throws Exception{
+            //given
+            String key = buildTodayAllKey();
+            Long productId = 101L;
+
+            //when
+            Optional<RankingsInfo.Ranking> ranking = rankingsService.getRanking(productId);
+
+            //then
+            assertThat(ranking).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("점수가 큰 제품이 높은 랭킹(낮은 숫자)의 랭킹 정보를 반환한다.")
+        public void returnHighRanking_whenScoreIsGreater() throws Exception{
+            //given
+            String key = buildTodayAllKey();
+            Long p1 = 1L;
+            Long p2 = 2L;
+            Long p3 = 3L;
+            stringRedisTemplate.opsForZSet().add(key, p1.toString(), 50.0);
+            stringRedisTemplate.opsForZSet().add(key, p2.toString(), 70.0);
+            stringRedisTemplate.opsForZSet().add(key, p3.toString(), 60.0);
+
+            //when
+            Optional<RankingsInfo.Ranking> r1 = rankingsService.getRanking(p1);
+            Optional<RankingsInfo.Ranking> r2 = rankingsService.getRanking(p2);
+            Optional<RankingsInfo.Ranking> r3 = rankingsService.getRanking(p3);
+
+            //then
+            assertThat(r2).isPresent();
+            assertThat(r2.get().getRank()).isEqualTo(1L);
+            assertThat(r2.get().getScore()).isEqualTo(70.0);
+
+            assertThat(r3).isPresent();
+            assertThat(r3.get().getRank()).isEqualTo(2L);
+
+            assertThat(r1).isPresent();
+            assertThat(r1.get().getRank()).isEqualTo(3L);
+        }
+    }
+
+    @DisplayName("상품 랭킹 요약 정보 조회")
+    @Nested
+    public class GetProductSummaryRanking {
+
+        @Test
+        @DisplayName("요청한 페이지 사이즈 만큼 상위 랭킹 상품을 순위대로 반환한다.")
+        public void returnsTopRankedProductsInOrder_whenPageSizeIsSpecified() throws Exception{
+            //given
+            String key = buildTodayAllKey();
+            Brand brand = brandRepository.save(Brand.create("Test Brand", "Test Description"));
+
+            Product p1 = productRepository.save(Product.create(brand.getId(), "Product1", 100L));
+            Product p2 = productRepository.save(Product.create(brand.getId(), "Product2", 100L));
+            Product p3 = productRepository.save(Product.create(brand.getId(), "Product3", 100L));
+
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p1.getId()), 30);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p2.getId()), 40);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p3.getId()), 50);
+
+            RankingsCommand.PageInfo page= RankingsCommand.PageInfo.of(LocalDate.now(), 1L, 2L, RankType.ALL_RANK);
+
+            //when
+            List<RankingsInfo.ProductSummary> productByRank = rankingsService.getProductByRank(page);
+
+
+            //then
+            assertThat(productByRank).hasSize(2);
+            assertThat(productByRank.get(0).getProduct().getProductId()).isEqualTo(p3.getId());
+            assertThat(productByRank.get(0).getRanking().getRank()).isEqualTo(1);
+            assertThat(productByRank.get(1).getProduct().getProductId()).isEqualTo(p2.getId());
+            assertThat(productByRank.get(1).getRanking().getRank()).isEqualTo(2);
+
+        }
+
+        @Test
+        @DisplayName("페이지네이션: size=2, page=2 요청 시 3위와 4위 상품이 순서대로 반환된다.")
+        void returnsThirdAndFourthRankedProducts_whenRequestingSecondPageWithPageSizeTwo() {
+            // given
+            String key = buildTodayAllKey();
+            Brand brand = brandRepository.save(Brand.create("B", "D"));
+
+            Product p1 = productRepository.save(Product.create(brand.getId(), "P1", 100L));
+            Product p2 = productRepository.save(Product.create(brand.getId(), "P2", 100L));
+            Product p3 = productRepository.save(Product.create(brand.getId(), "P3", 100L));
+            Product p4 = productRepository.save(Product.create(brand.getId(), "P4", 100L));
+            Product p5 = productRepository.save(Product.create(brand.getId(), "P5", 100L));
+
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p1.getId()), 10);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p2.getId()), 20);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p3.getId()), 30);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p4.getId()), 40);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p5.getId()), 50);
+
+            RankingsCommand.PageInfo page = RankingsCommand.PageInfo.of(LocalDate.now(), 2L, 2L, RankType.ALL_RANK);
+
+            // when
+            List<RankingsInfo.ProductSummary> result = rankingsService.getProductByRank(page);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getProduct().getProductId()).isEqualTo(p3.getId());
+            assertThat(result.get(0).getRanking().getRank()).isEqualTo(3L);
+            assertThat(result.get(1).getProduct().getProductId()).isEqualTo(p2.getId());
+            assertThat(result.get(1).getRanking().getRank()).isEqualTo(4L);
+        }
+
+        @Test
+        @DisplayName("Redis에 존재하지만 DB에 존재하지 않는 상품 ID가 포함되면 IllegalArgumentException 예외를 던진다.")
+        void throwsException_whenRedisHasUnknownProductId() {
+            // given
+            String key = buildTodayAllKey();
+            Brand brand = brandRepository.save(Brand.create("B", "D"));
+            Product p = productRepository.save(Product.create(brand.getId(), "P", 100L));
+
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(p.getId()), 50);
+            stringRedisTemplate.opsForZSet().add(key, String.valueOf(999999L), 60);
+
+            RankingsCommand.PageInfo page = RankingsCommand.PageInfo.of(LocalDate.now(), 1L, 10L, RankType.ALL_RANK);
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> rankingsService.getProductByRank(page))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Product not found");
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/rankings/RankingFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/rankings/RankingFixture.java
@@ -1,0 +1,72 @@
+package com.loopers.fixture.rankings;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.stock.Stock;
+import com.loopers.domain.stock.StockRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+public class RankingFixture {
+    private final BrandRepository brandRepository;
+    private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
+    private final LikeRepository likeRepository;
+    private final StringRedisTemplate redis;
+    private final Supplier<String> todayAllKeySupplier;
+
+    public RankingFixture(BrandRepository brandRepository,
+            ProductRepository productRepository,
+            StockRepository stockRepository,
+            LikeRepository likeRepository,
+            StringRedisTemplate redis,
+            Supplier<String> todayAllKeySupplier) {
+        this.brandRepository = brandRepository;
+        this.productRepository = productRepository;
+        this.stockRepository = stockRepository;
+        this.likeRepository = likeRepository;
+        this.redis = redis;
+        this.todayAllKeySupplier = todayAllKeySupplier;
+    }
+
+    public Brand brand(String name) {
+        return brandRepository.save(Brand.create(name, "DESC"));
+    }
+
+    public Product product(Brand brand, String name, long price) {
+        return productRepository.save(Product.create(brand.getId(), name, price));
+    }
+
+    public Stock stock(Product product, long qty) {
+        return stockRepository.save(Stock.create(product.getId(), qty));
+    }
+
+    public void like(String userId, Product product) {
+        likeRepository.save(Like.create(userId, product.getId()));
+    }
+
+    public void zadd(Product product, double score) {
+        redis.opsForZSet().add(todayAllKeySupplier.get(), String.valueOf(product.getId()), score);
+    }
+
+    public void zadd(Map<Product, Double> scores) {
+        scores.forEach(this::zadd);
+    }
+
+    record ProdSet(Product p, Stock s, double score) {}
+    List<RankingFixture.ProdSet> seedRankings(Brand brand, List<RankingFixture.ProdSet> sets) {
+        for (RankingFixture.ProdSet set : sets) {
+            stock(set.p(), set.s().getQuantity());
+            zadd(set.p(), set.score());
+        }
+        return sets;
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/event/external/ExternalDataPlatformListenerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/event/external/ExternalDataPlatformListenerTest.java
@@ -3,10 +3,13 @@ package com.loopers.interfaces.api.event.external;
 import com.loopers.domain.external.ExternalDataService;
 import com.loopers.domain.external.OrderResultPayload;
 import com.loopers.domain.order.OrderEvent;
+import com.loopers.domain.sender.MessageSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -15,7 +18,8 @@ import static org.mockito.Mockito.verify;
 class ExternalDataPlatformListenerTest {
 
     private final ExternalDataService externalDataService = mock(ExternalDataService.class);
-    private final ExternalDataPlatformListener listener = new ExternalDataPlatformListener(externalDataService);
+    private final MessageSender messageSender = mock(MessageSender.class);
+    private final ExternalDataPlatformListener listener = new ExternalDataPlatformListener(externalDataService, messageSender);
 
     @Nested
     @DisplayName("주문 완료 외부 데이터 연동 이벤트 테스트")
@@ -25,10 +29,11 @@ class ExternalDataPlatformListenerTest {
         @DisplayName("Order 완료 이벤트를 수신하면 외부 전송 함수가 호출된다.")
         void callSendToExternalPlatform_whenOrderCompletedEventReceived() {
             // given
+            String userId = "hoyong";
             Long orderId = 1L;
             String orderNumber = "ORDER-123456";
             Long amount = 15000L;
-            OrderEvent.Completed event = OrderEvent.Completed.of(orderId, orderNumber, amount);
+            OrderEvent.Completed event = OrderEvent.Completed.of(userId, orderId, orderNumber, amount, List.of(OrderEvent.OrderProduct.of(1L, 1L)));
 
             // when
             listener.handle(event);

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductApiE2ETest.java
@@ -1,13 +1,12 @@
 package com.loopers.interfaces.api.product;
 
-import com.loopers.application.product.ProductFacade;
-import com.loopers.application.product.ProductResult;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.sender.MessageSender;
 import com.loopers.domain.stock.Stock;
 import com.loopers.domain.stock.StockRepository;
 import com.loopers.interfaces.api.ApiResponse;
@@ -15,6 +14,7 @@ import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
@@ -51,6 +51,9 @@ class ProductApiE2ETest {
     void tearDown() {
         databaseCleanUp.truncateAllTables();
     }
+
+    @MockBean
+    private MessageSender messageSender;
 
 
     @DisplayName("상품 조회 E2E 테스트")

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/rankings/RankingApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/rankings/RankingApiE2ETest.java
@@ -1,0 +1,218 @@
+package com.loopers.interfaces.api.rankings;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.sender.MessageSender;
+import com.loopers.domain.stock.StockRepository;
+import com.loopers.fixture.rankings.RankingFixture;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RankingApiE2ETest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @MockBean
+    private MessageSender messageSender;
+
+    private RankingFixture fixture;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+        stringRedisTemplate.delete(todayAllKey());
+    }
+
+    @BeforeEach
+    void setUp() {
+        fixture = new RankingFixture(
+                brandRepository,
+                productRepository,
+                stockRepository,
+                likeRepository,
+                stringRedisTemplate,
+                this::todayAllKey
+        );
+    }
+
+    private String todayAllKey() {
+        return "rank:all:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now());
+    }
+
+    private ResponseEntity<ApiResponse<RankingsResponse.Rankings>> getRankings(
+            HttpHeaders headers, String query
+    ) {
+        ParameterizedTypeReference<ApiResponse<RankingsResponse.Rankings>> type =
+                new ParameterizedTypeReference<>() {};
+        return restTemplate.exchange(
+                "/api/v1/rankings" + query,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                type
+        );
+    }
+
+    @Nested
+    @DisplayName("랭킹 조회 E2E")
+    class GetRankings {
+
+        @Test
+        @DisplayName("로그인 사용자가 요청한 페이지 사이즈만큼 상위 랭킹 상품을 순위대로 반환한다 (size=2, page=1)")
+        void returnsTopRankedProductsInOrder_whenPageSizeIsSpecified_andLoggedIn() {
+            // given
+            String userId = "hoyo";
+            Brand brand = fixture.brand("B");
+
+            Product p1 = fixture.product(brand, "P1", 1000L);
+            Product p2 = fixture.product(brand, "P2", 2000L);
+            Product p3 = fixture.product(brand, "P3", 3000L);
+
+            fixture.stock(p1, 100L);
+            fixture.stock(p2, 100L);
+            fixture.stock(p3, 100L);
+
+            fixture.like(userId, p2);
+
+            fixture.zadd(p1, 30.0);
+            fixture.zadd(p2, 40.0);
+            fixture.zadd(p3, 50.0);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+            String query = "?date=" + LocalDate.now() + "&size=2&page=1";
+
+            ParameterizedTypeReference<ApiResponse<RankingsResponse.Rankings>> responseType =
+                    new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<RankingsResponse.Rankings>> response = restTemplate.exchange(
+                    "/api/v1/rankings" + query,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    responseType
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().getRankings()).hasSize(2),
+                    () -> {
+                        RankingsResponse.Product r1 = response.getBody().data().getRankings().get(0);
+                        assertThat(r1.getProductName()).isEqualTo("P3");
+                        assertThat(r1.getBrandName()).isEqualTo("B");
+                        assertThat(r1.getPrice()).isEqualTo(3000L);
+                        assertThat(r1.getRank()).isEqualTo(1L);
+                        assertThat(r1.getIsLiked()).isFalse();
+                    },
+
+                    () -> {
+                        RankingsResponse.Product r2 = response.getBody().data().getRankings().get(1);
+                        assertThat(r2.getProductName()).isEqualTo("P2");
+                        assertThat(r2.getBrandName()).isEqualTo("B");
+                        assertThat(r2.getPrice()).isEqualTo(2000L);
+                        assertThat(r2.getRank()).isEqualTo(2L);
+                        assertThat(r2.getIsLiked()).isTrue();
+                    }
+            );
+        }
+
+        @Test
+        @DisplayName("비로그인 사용자는 liked=false로 반환되며, 페이지네이션에 따라 다음 페이지가 올바르게 반환된다 (size=2, page=2)")
+        void returnsSecondPageInOrder_whenPageIsTwo_andAnonymous() {
+            // given
+            Brand brand = fixture.brand("B");
+
+            Product p1 = fixture.product(brand, "P1", 1000L);
+            Product p2 = fixture.product(brand, "P2", 2000L);
+            Product p3 = fixture.product(brand, "P3", 3000L);
+
+            fixture.stock(p1, 100L);
+            fixture.stock(p2, 100L);
+            fixture.stock(p3, 100L);
+
+            fixture.like("u1", p2);
+            fixture.like("u2", p3);
+
+            fixture.zadd(p1, 40.0);
+            fixture.zadd(p2, 50.0);
+            fixture.zadd(p3, 60.0);
+
+            HttpHeaders headers = new HttpHeaders();
+            String query = "?date=" + LocalDate.now() + "&size=2&page=2";
+
+            // when
+            ResponseEntity<ApiResponse<RankingsResponse.Rankings>> response = getRankings(headers, query);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().getRankings()).hasSize(1),
+                    () -> {
+                        RankingsResponse.Product last = response.getBody().data().getRankings().get(0);
+                        assertThat(last.getProductName()).isEqualTo("P1");
+                        assertThat(last.getRank()).isEqualTo(3L);
+                        assertThat(last.getIsLiked()).isFalse();
+                    }
+            );
+        }
+
+        @Test
+        @DisplayName("랭킹 데이터가 없으면 빈 목록을 반환한다")
+        void returnsEmptyList_whenNoRankingData() {
+            // given
+            Brand brand = fixture.brand("B");
+            Product p1 = fixture.product(brand, "P1", 1000L);
+            fixture.stock(p1, 10L);
+
+            HttpHeaders headers = new HttpHeaders();
+            String query = "?date=" + LocalDate.now() + "&size=20&page=1";
+
+            // when
+            ResponseEntity<ApiResponse<RankingsResponse.Rankings>> response = getRankings(headers, query);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().getRankings()).isEmpty()
+            );
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/CommerceCollectorApplication.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/CommerceCollectorApplication.java
@@ -3,9 +3,11 @@ package com.loopers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableScheduling
 public class CommerceCollectorApplication {
     public static void main(String[] args) {
         SpringApplication.run(CommerceCollectorApplication.class, args);

--- a/apps/commerce-collector/src/main/java/com/loopers/application/order/OrderEventConsumerHandler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/order/OrderEventConsumerHandler.java
@@ -1,0 +1,28 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.eventhandled.EventHandledService;
+import com.loopers.domain.metric.ProductMetricService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OrderEventConsumerHandler {
+
+    private final EventHandledService eventHandledService;
+
+    private final ProductMetricService productMetricService;
+
+    @Transactional
+    public void handleOrderEvent(OrderEventCriteria.Order event) {
+
+        boolean isNewEvent = eventHandledService.processIfNotHandled(event.getEventId(), event.getTopic(), event.getPartition(),
+                event.getOffset());
+        if (!isNewEvent) {
+            return;
+        }
+
+        productMetricService.upsertSales(event.getProductId(), event.metricDate(), event.delta(), event.getEventTime());
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/order/OrderEventCriteria.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/order/OrderEventCriteria.java
@@ -1,0 +1,49 @@
+package com.loopers.application.order;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class OrderEventCriteria {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Order {
+        private String eventId;
+        private String topic;
+        private Integer partition;
+        private Long offset;
+        private LocalDateTime eventTime;
+        private Long productId;
+        private Long orderId;
+        private Long quantity;
+        private String orderNumber;
+
+        public static Order of(String eventId, String topic, Integer partition, Long offset, Long productId, Long orderId, String orderNumber, Long quantity, LocalDateTime eventTime) {
+            return Order.builder()
+                    .eventId(eventId)
+                    .topic(topic)
+                    .partition(partition)
+                    .offset(offset)
+                    .productId(productId)
+                    .orderId(orderId)
+                    .orderNumber(orderNumber)
+                    .quantity(quantity)
+                    .eventTime(eventTime)
+                    .build();
+        }
+
+        public LocalDate metricDate() {
+            return eventTime.toLocalDate();
+        }
+
+        public Long delta() {
+            return quantity;
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/pageview/PageViewEventConsumerHandler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/pageview/PageViewEventConsumerHandler.java
@@ -1,0 +1,27 @@
+package com.loopers.application.pageview;
+
+import com.loopers.domain.eventhandled.EventHandledService;
+import com.loopers.domain.metric.ProductMetricService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PageViewEventConsumerHandler {
+    private final EventHandledService eventHandledService;
+
+    private final ProductMetricService productMetricService;
+
+    @Transactional
+    public void handlePageViewEvent(PageViewEventCriteria.View event) {
+
+        boolean isNewEvent = eventHandledService.processIfNotHandled(event.getEventId(), event.getTopic(), event.getPartition(),
+                event.getOffset());
+        if (!isNewEvent) {
+            return;
+        }
+
+        productMetricService.upsertPageView(event.getProductId(), event.metricDate(), event.delta(), event.getEventTime());
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/pageview/PageViewEventCriteria.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/pageview/PageViewEventCriteria.java
@@ -1,0 +1,43 @@
+package com.loopers.application.pageview;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class PageViewEventCriteria {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class View {
+        private String eventId;
+        private String topic;
+        private Integer partition;
+        private Long offset;
+        private Long productId;
+        private LocalDateTime eventTime;
+
+        public static View of(String eventId, String topic, Integer partition, Long offset, Long productId, LocalDateTime eventTime) {
+            return View.builder()
+                    .eventId(eventId)
+                    .topic(topic)
+                    .partition(partition)
+                    .offset(offset)
+                    .productId(productId)
+                    .eventTime(eventTime)
+                    .build();
+        }
+
+        public LocalDate metricDate() {
+            return eventTime.toLocalDate();
+        }
+
+        public Long delta() {
+            return 1L;
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/config/RankingProperties.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/config/RankingProperties.java
@@ -1,0 +1,45 @@
+package com.loopers.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "ranking")
+@Getter @Setter
+public class RankingProperties {
+    private long ttlHours = 36;
+
+    private Weight weight = new Weight();
+
+    private CarryOver carryOver = new CarryOver();
+
+    @Getter @Setter
+    public static class Weight {
+        private double like = 0.2;
+        private double sales = 0.7;
+        private double pv = 0.1;
+    }
+
+    @Getter @Setter
+    public static class CarryOver {
+        /** 캐리오버 기능 on/off */
+        private boolean enabled = true;
+
+        /** 스케줄 크론 (예: "0 0 0 * * *") */
+        private String cron = "0 0 0 * * *";
+
+        /** 타임존 (예: "Asia/Seoul") */
+        private String zone = "Asia/Seoul";
+
+        /** 전일 점수 이월 비율 (0.1 = 10%) */
+        private double rate = 0.10;
+
+        /** 분산락 키 */
+        private String lockKey = "_lock:ranking:carryover:daily";
+
+        /** 분산락 TTL(초) */
+        private long lockTtlSeconds = 300L;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/metric/ProductMetricRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/metric/ProductMetricRepository.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.metric;
 
-import org.springframework.data.repository.query.Param;
-
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -21,4 +20,8 @@ public interface ProductMetricRepository {
                         LocalDate metricDate,
                         Long count,
                         LocalDateTime eventTime);
+
+    void carryOver(LocalDate today, double rate, Duration hour);
+
+    void rebuildDailyAllRankings(LocalDate date);
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/metric/ProductMetricService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/metric/ProductMetricService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -24,7 +25,23 @@ public class ProductMetricService {
     }
 
     @Transactional
-    public void insertPageView(Long productId, LocalDate metricDate, Long count, LocalDateTime eventTime) {
+    public void upsertPageView(Long productId, LocalDate metricDate, Long count, LocalDateTime eventTime) {
         productMetricRepository.upsertPageView(productId, metricDate, count, eventTime);
+    }
+
+    /**
+     * 캐리오버 실행
+     * @param today 기준 날짜 (보통 LocalDate.now(zone))
+     * @param rate 전일 점수 이월 비율 (0.1 = 10%)
+     * @param ttlHours 캐리오버된 ZSET의 TTL (시간 단위)
+     */
+    @Transactional
+    public void scoreCarry(LocalDate today, double rate, long ttlHours) {
+        productMetricRepository.carryOver(today, rate, Duration.ofHours(ttlHours));
+    }
+
+    @Transactional
+    public void rebuildAllRankings(LocalDate date) {
+        productMetricRepository.rebuildDailyAllRankings(date);
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricCacheRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricCacheRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.productmetric;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+public interface ProductMetricCacheRepository {
+    void upsertLike(Long productId, LocalDate metricDate, Long delta);
+    void upsertSales(Long productId, LocalDate metricDate, Long delta);
+    void upsertPageViews(Long productId, LocalDate metricDate, Long delta);
+    void carryOver(LocalDate today, Double rate, Duration hour);
+    void rebuildDailyAllRankings(LocalDate date);
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricRedisRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricRedisRepositoryImpl.java
@@ -1,0 +1,128 @@
+package com.loopers.infrastructure.productmetric;
+
+import com.loopers.config.RankingProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.zset.Aggregate;
+import org.springframework.data.redis.connection.zset.Weights;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductMetricRedisRepositoryImpl implements ProductMetricCacheRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final RankingProperties rankingProperties;
+
+    private static final DateTimeFormatter KEY_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+
+    @Override
+    public void upsertLike(Long productId, LocalDate metricDate, Long delta) {
+        final String ymd = dateKey(metricDate);
+        final String member = productId.toString();
+
+        zincrBy(likeKey(ymd), member, delta);
+        // TODO : 스케쥴러로 안하고 바로 all에 추가하면 어떨까?
+        //zincrBy(allKey(ymd), member, delta * rankingProperties.getWeight().getLike());
+    }
+
+    @Override
+    public void upsertSales(Long productId, LocalDate metricDate, Long delta) {
+        final String ymd = dateKey(metricDate);
+        final String member = productId.toString();
+
+        zincrBy(salesKey(ymd), member, delta);
+        //zincrBy(allKey(ymd), member, delta * rankingProperties.getWeight().getSales());
+    }
+
+    @Override
+    public void upsertPageViews(Long productId, LocalDate metricDate, Long delta) {
+        final String ymd = dateKey(metricDate);
+        final String member = productId.toString();
+
+        zincrBy(pvKey(ymd), member, delta);
+        //zincrBy(allKey(ymd), member, delta * rankingProperties.getWeight().getPv());
+    }
+
+    @Override
+    public void carryOver(LocalDate today, Double rate, Duration hour) {
+        String todayKey = allKey(KEY_DATE.format(today));
+        String yestKey  = allKey(KEY_DATE.format(today.minusDays(1)));
+
+        redisTemplate.opsForZSet()
+                .unionAndStore(
+                        todayKey,
+                        java.util.Collections.singleton(yestKey),
+                        todayKey,
+                        Aggregate.SUM,
+                        Weights.of(1.0, rate)
+                );
+
+        ensureTtl(todayKey);
+
+    }
+
+    @Override
+    public void rebuildDailyAllRankings(LocalDate date) {
+        final String ymd = dateKey(date);
+
+        redisTemplate.opsForZSet().unionAndStore(
+                likeKey(ymd),
+                List.of(salesKey(ymd), pvKey(ymd)),
+                allKey(ymd),
+                Aggregate.SUM,
+                Weights.of(
+                        rankingProperties.getWeight().getLike(),
+                        rankingProperties.getWeight().getSales(),
+                        rankingProperties.getWeight().getPv()
+                )
+        );
+
+        ensureTtl(allKey(ymd));
+    }
+
+    private String dateKey(LocalDate date) {
+        return KEY_DATE.format(date);
+    }
+
+    private void zincrBy(String key, String productId, Long delta) {
+        ZSetOperations<String, String> z = redisTemplate.opsForZSet();
+        Double newScore = z.incrementScore(key, productId, delta);
+        if (newScore < 0) {
+            z.add(key, productId, 0);
+        }
+        ensureTtl(key);
+    }
+
+    private void ensureTtl(String key) {
+        Long ttlSeconds = redisTemplate.getExpire(key);
+        if (ttlSeconds == null || ttlSeconds < 0) {
+            Duration ttl = Duration.ofHours(rankingProperties.getTtlHours());
+            redisTemplate.expire(key, ttl);
+        }
+    }
+
+    private String likeKey(String ymd) {
+        return "rank:like:" + ymd;
+    }
+
+    private String salesKey(String ymd) {
+        return "rank:sales:" + ymd;
+    }
+
+    private String pvKey(String ymd) {
+        return "rank:pv:" + ymd;
+    }
+
+    private String allKey(String ymd) {
+        return "rank:all:" + ymd;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/productmetric/ProductMetricRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.metric.ProductMetricRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -13,18 +14,33 @@ public class ProductMetricRepositoryImpl implements ProductMetricRepository {
 
     private final ProductMetricJpaRepository productMetricJpaRepository;
 
+    private final ProductMetricCacheRepository productMetricCacheRepository;
+
     @Override
     public void upsertLike(Long productId, LocalDate metricDate, Long count, LocalDateTime eventTime) {
         productMetricJpaRepository.upsertLike(productId, metricDate, count, eventTime);
+        productMetricCacheRepository.upsertLike(productId, metricDate, count);
     }
 
     @Override
     public void upsertSales(Long productId, LocalDate metricDate, Long count, LocalDateTime eventTime) {
         productMetricJpaRepository.upsertSales(productId, metricDate, count, eventTime);
+        productMetricCacheRepository.upsertSales(productId, metricDate, count);
     }
 
     @Override
     public void upsertPageView(Long productId, LocalDate metricDate, Long count, LocalDateTime eventTime) {
         productMetricJpaRepository.upsertPageView(productId, metricDate, count, eventTime);
+        productMetricCacheRepository.upsertPageViews(productId, metricDate, count);
+    }
+
+    @Override
+    public void carryOver(LocalDate today, double rate, Duration hour) {
+        productMetricCacheRepository.carryOver(today, rate, hour);
+    }
+
+    @Override
+    public void rebuildDailyAllRankings(LocalDate date) {
+        productMetricCacheRepository.rebuildDailyAllRankings(date);
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/order/OrderEventConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/order/OrderEventConsumer.java
@@ -1,0 +1,63 @@
+package com.loopers.interfaces.consumer.order;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.order.OrderEventConsumerHandler;
+import com.loopers.application.order.OrderEventCriteria;
+import com.loopers.common.kafka.event.EventMessage;
+import com.loopers.common.kafka.event.order.OrderOutEvent;
+import com.loopers.common.kafka.topic.Topics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventConsumer {
+
+    private final OrderEventConsumerHandler orderEventConsumerHandler;
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = {Topics.ORDER,}, groupId = "order-event-consumer-group")
+    public void handleOrderEvent(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        try {
+            String message = record.value();
+            String topic = record.topic();
+            Integer partition = record.partition();
+            Long offset = record.offset();
+
+            EventMessage<OrderOutEvent.Order> event = objectMapper.readValue(
+                    message,
+                    new TypeReference<EventMessage<OrderOutEvent.Order>>() {}
+            );
+            OrderOutEvent.Order payload = event.getPayload();
+
+            orderEventConsumerHandler.handleOrderEvent(
+                    OrderEventCriteria.Order.of(
+                            event.getPayload().getEventId(),
+                            topic,
+                            partition,
+                            offset,
+                            payload.getProductId(),
+                            payload.getOrderId(),
+                            payload.getOrderNumber(),
+                            payload.getQuantity(),
+                            payload.getEventTime()
+                    )
+            );
+
+            ack.acknowledge();
+
+        } catch (Exception e) {
+            log.error("[Kafka] ORDER 이벤트 처리 중 예외 발생: {}", e);
+        }
+    }
+
+
+
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/pageview/PageViewEventConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/pageview/PageViewEventConsumer.java
@@ -1,0 +1,57 @@
+package com.loopers.interfaces.consumer.pageview;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.pageview.PageViewEventConsumerHandler;
+import com.loopers.application.pageview.PageViewEventCriteria;
+import com.loopers.common.kafka.event.EventMessage;
+import com.loopers.common.kafka.event.pageview.PageViewOutEvent;
+import com.loopers.common.kafka.topic.Topics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PageViewEventConsumer {
+    private final PageViewEventConsumerHandler pageViewEventConsumerHandler;
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = {Topics.PAGE_VIEW,}, groupId = "page-view-event-consumer-group")
+    public void handlePageViewEvent(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        try {
+            String message = record.value();
+            String topic = record.topic();
+            Integer partition = record.partition();
+            Long offset = record.offset();
+
+            EventMessage<PageViewOutEvent.Viewed> event = objectMapper.readValue(
+                    message,
+                    new TypeReference<EventMessage<PageViewOutEvent.Viewed>>() {}
+            );
+            PageViewOutEvent.Viewed payload = event.getPayload();
+
+            pageViewEventConsumerHandler.handlePageViewEvent(
+                    PageViewEventCriteria.View.of(
+                            event.getPayload().getEventId(),
+                            topic,
+                            partition,
+                            offset,
+                            payload.getProductId(),
+                            payload.getEventTime()
+                    )
+            );
+
+            ack.acknowledge();
+
+        } catch (Exception e) {
+            log.error("[Kafka] PageView 처리 중 예외 발생: {}", e);
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingCarryOverScheduler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingCarryOverScheduler.java
@@ -1,0 +1,35 @@
+package com.loopers.interfaces.scheduler;
+
+import com.loopers.config.RankingProperties;
+import com.loopers.domain.metric.ProductMetricService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class RankingCarryOverScheduler {
+
+    private final ProductMetricService productMetricService;
+
+    private final RankingProperties rankingProperties;
+
+    @Scheduled(cron = "0 50 23 * * *", zone = "Asia/Seoul")
+    public void prewarmTomorrow() {
+        scoreCarryOver();
+    }
+
+    private void scoreCarryOver() {
+        if(!rankingProperties.getCarryOver().isEnabled()) {
+            return;
+        }
+
+        LocalDate today = LocalDate.now();
+        double rate = rankingProperties.getCarryOver().getRate();
+        long ttlHours = rankingProperties.getTtlHours();
+        productMetricService.scoreCarry(today, rate, ttlHours);
+    }
+
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingScheduler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingScheduler.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.scheduler;
+
+import com.loopers.domain.metric.ProductMetricService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+
+    private final ProductMetricService productMetricService;
+
+    @Scheduled(cron = "0 * * * * *")
+    public void rebuildAllRankings() {
+        productMetricService.rebuildAllRankings(LocalDate.now());
+    }
+}

--- a/apps/commerce-collector/src/test/java/com/loopers/application/order/OrderEventConsumerHandlerTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/application/order/OrderEventConsumerHandlerTest.java
@@ -1,0 +1,89 @@
+package com.loopers.application.order;
+
+import com.loopers.common.kafka.topic.Topics;
+import com.loopers.domain.eventhandled.EventHandledService;
+import com.loopers.domain.metric.ProductMetricService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderEventConsumerHandlerTest {
+
+    @Mock
+    EventHandledService eventHandledService;
+
+    @Mock
+    ProductMetricService productMetricService;
+
+    @InjectMocks
+    OrderEventConsumerHandler handler;
+
+    private OrderEventCriteria.Order orderEvent(String eventId, Long productId, Long orderId, String orderNumber, Long quantity) {
+        return OrderEventCriteria.Order.of(
+                eventId,
+                Topics.ORDER,
+                0,
+                1L,
+                productId,
+                orderId,
+                orderNumber,
+                quantity,
+                LocalDateTime.now()
+        );
+    }
+
+    @DisplayName("중복 주문 이벤트가 순차적으로 도착해도 upsertSales는 한 번만 호출된다.")
+    @Test
+    void upsertSalesIsCalledOnlyOnce_whenDuplicateOrderEventsArriveSequentially() {
+        // given
+        Long productId = 1L;
+        Long orderId = 1L;
+        Long quantity = 1L;
+        String orderNumber = UUID.randomUUID().toString();
+        String eventId = UUID.randomUUID().toString();
+        OrderEventCriteria.Order event = orderEvent(eventId,  productId, orderId, orderNumber, quantity);
+
+        when(eventHandledService.processIfNotHandled(anyString(), anyString(), anyInt(), anyLong()))
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(false);
+
+        // when
+        handler.handleOrderEvent(event);
+        handler.handleOrderEvent(event);
+        handler.handleOrderEvent(event);
+
+        // then
+        verify(productMetricService, times(1))
+                .upsertSales(eq(orderId), eq(event.metricDate()), eq(1L), eq(event.getEventTime()));
+
+        verifyNoMoreInteractions(productMetricService);
+    }
+
+    @DisplayName("이벤트가 이미 처리된 경우 upsertSales는 호출되지 않는다.")
+    @Test
+    void upsertSalesIsNotCalled_whenEventHandledServiceReturnsFalse() {
+        // given
+        OrderEventCriteria.Order event = orderEvent(UUID.randomUUID().toString(), 1L, 1L, UUID.randomUUID().toString(), 1L);
+
+        when(eventHandledService.processIfNotHandled(anyString(), anyString(), anyInt(), anyLong()))
+                .thenReturn(false);
+
+        // when
+        handler.handleOrderEvent(event);
+
+        // then
+        verify(productMetricService, never())
+                .upsertSales(anyLong(), any(LocalDate.class), anyLong(), any(LocalDateTime.class));
+    }
+}

--- a/apps/commerce-collector/src/test/java/com/loopers/application/order/OrderEventConsumerHandlerTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/application/order/OrderEventConsumerHandlerTest.java
@@ -63,6 +63,7 @@ class OrderEventConsumerHandlerTest {
         handler.handleOrderEvent(event);
         handler.handleOrderEvent(event);
 
+
         // then
         verify(productMetricService, times(1))
                 .upsertSales(eq(orderId), eq(event.metricDate()), eq(1L), eq(event.getEventTime()));

--- a/apps/commerce-collector/src/test/java/com/loopers/application/pageview/PageViewEventConsumerHandlerTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/application/pageview/PageViewEventConsumerHandlerTest.java
@@ -1,0 +1,92 @@
+package com.loopers.application.pageview;
+
+import com.loopers.common.kafka.topic.Topics;
+import com.loopers.domain.eventhandled.EventHandledService;
+import com.loopers.domain.metric.ProductMetricService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PageViewEventConsumerHandlerTest {
+
+    @Mock
+    EventHandledService eventHandledService;
+
+    @Mock
+    ProductMetricService productMetricService;
+
+    @InjectMocks
+    PageViewEventConsumerHandler handler;
+
+    private PageViewEventCriteria.View view(String eventId, Long productId) {
+        return PageViewEventCriteria.View.of(
+                eventId,
+                Topics.PAGE_VIEW,
+                0,
+                1L,
+                productId,
+                LocalDateTime.now()
+        );
+    }
+    @Test
+    @DisplayName("중복 페이지뷰 이벤트가 순차적으로 도착해도 upsertPageView는 한 번만 호출된다.")
+    void upsertPageViewIsCalledOnlyOnce_whenDuplicateEventsArriveSequentially() {
+        // given
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 1L;
+
+        PageViewEventCriteria.View event =
+                view(eventId, productId);
+
+        when(eventHandledService.processIfNotHandled(eventId, event.getTopic(), event.getPartition(), event.getOffset()))
+                .thenReturn(true)
+                .thenReturn(false)
+                .thenReturn(false);
+
+        // when
+        handler.handlePageViewEvent(event);
+        handler.handlePageViewEvent(event);
+        handler.handlePageViewEvent(event);
+
+        // then
+        verify(productMetricService, times(1))
+                .upsertPageView(eq(productId), eq(event.metricDate()), eq(1L), eq(event.getEventTime()));
+
+        verify(eventHandledService, times(3))
+                .processIfNotHandled(eq(eventId), eq(event.getTopic()), eq(event.getPartition()), eq(event.getOffset()));
+
+        verifyNoMoreInteractions(productMetricService);
+    }
+
+    @Test
+    @DisplayName("이벤트가 이미 처리된 경우 upsertPageView는 호출되지 않는다.")
+    void upsertPageViewIsNotCalled_whenEventAlreadyHandled() {
+        // given
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 1L;
+
+        PageViewEventCriteria.View event =
+                view(eventId, productId);
+
+
+        when(eventHandledService.processIfNotHandled(anyString(), anyString(), anyInt(), anyLong()))
+                .thenReturn(false);
+
+        // when
+        handler.handlePageViewEvent(event);
+
+        // then
+        verify(productMetricService, never())
+                .upsertPageView(anyLong(), any(LocalDate.class), anyLong(), any(LocalDateTime.class));
+    }
+}

--- a/apps/commerce-collector/src/test/java/com/loopers/domain/metric/ProductMetricServiceIntegrationTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/domain/metric/ProductMetricServiceIntegrationTest.java
@@ -1,0 +1,196 @@
+package com.loopers.domain.metric;
+
+import com.loopers.config.RankingProperties;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProductMetricServiceIntegrationTest {
+
+    @Autowired
+    private ProductMetricService productMetricService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private RankingProperties rankingProperties;
+
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
+    private String likeKey(LocalDate d) {
+        return "rank:like:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(d);
+    }
+
+    private String salesKey(LocalDate d) {
+        return "rank:sales:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(d);
+    }
+
+    private String pvKey(LocalDate d) {
+        return "rank:pv:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(d);
+    }
+
+    private String allKey(LocalDate d) {
+        return "rank:all:" + DateTimeFormatter.ofPattern("yyyyMMdd").format(d);
+    }
+
+    private void assertTtlRoughlyHours(String key, long expectedHours) {
+        Long ttlSec = redisTemplate.getExpire(key);
+        assertThat(ttlSec).isNotNull();
+        assertThat(ttlSec).isGreaterThan(0);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+    }
+
+    @Nested
+    @DisplayName("redis insert 테스트")
+    public class RedisInsert {
+
+        @Test
+        @DisplayName("upsertLike 호출 시 당일 like ZSET 점수가 증가하고 TTL이 설정된다")
+        void increasesLikeScoreAndSetsTtl_whenUpsertLike() {
+            // given
+            LocalDate today = LocalDate.now();
+            Long productId = 101L;
+            LocalDateTime eventTime = LocalDateTime.now();
+
+            // when
+            productMetricService.upsertLike(productId, today, 2L, eventTime);
+
+            // then
+            Double score = redisTemplate.opsForZSet()
+                    .score(likeKey(today), productId.toString());
+            assertThat(score).isNotNull();
+            assertThat(score).isEqualTo(2.0);
+
+            assertTtlRoughlyHours(likeKey(today), rankingProperties.getTtlHours());
+        }
+
+        @Test
+        @DisplayName("upsertSales 호출 시 당일 sales ZSET 점수가 증가하고 TTL이 설정된다")
+        void increasesSalesScoreAndSetsTtl_whenUpsertSales() {
+            // given
+            LocalDate today = LocalDate.now();
+            Long productId = 202L;
+
+            // when
+            productMetricService.upsertSales(productId, today, 5L, LocalDateTime.now());
+
+            // then
+            Double score = redisTemplate.opsForZSet()
+                    .score(salesKey(today), productId.toString());
+            assertThat(score).isNotNull();
+            assertThat(score).isEqualTo(5.0);
+
+            assertTtlRoughlyHours(salesKey(today), rankingProperties.getTtlHours());
+        }
+
+        @Test
+        @DisplayName("upsertPageView 호출 시 당일 pv ZSET 점수가 증가하고 TTL이 설정된다")
+        void increasesPvScoreAndSetsTtl_whenUpsertPageView() {
+            // given
+            LocalDate today = LocalDate.now();
+            Long productId = 303L;
+
+            // when
+            productMetricService.upsertPageView(productId, today, 7L, LocalDateTime.now());
+
+            // then
+            Double score = redisTemplate.opsForZSet()
+                    .score(pvKey(today), productId.toString());
+            assertThat(score).isNotNull();
+            assertThat(score).isEqualTo(7.0);
+
+            assertTtlRoughlyHours(pvKey(today), rankingProperties.getTtlHours());
+        }
+
+
+    }
+
+    @Nested
+    @DisplayName("carryOver 테스트")
+    public class CarryOver {
+
+        @Test
+        @DisplayName("오늘 all이 비어있는 상태에서 전일 all * rate 가 오늘 all로 머지된다")
+        void mergesYesterdayAllIntoEmptyToday_whenScoreCarryOverwithRate() {
+            // given
+            LocalDate today = LocalDate.now();
+            LocalDate yesterday = today.minusDays(1);
+
+            String tKey = allKey(today);
+            String yKey = allKey(yesterday);
+
+            redisTemplate.delete(tKey);
+
+            redisTemplate.opsForZSet().add(yKey, "1", 20.0);
+            redisTemplate.opsForZSet().add(yKey, "2", 30.0);
+
+            double rate = 0.1;
+            long ttlHours = rankingProperties.getTtlHours();
+
+            // when
+            productMetricService.scoreCarry(today, rate, ttlHours);
+
+            // then
+            Double p1 = redisTemplate.opsForZSet().score(tKey, "1");
+            Double p2 = redisTemplate.opsForZSet().score(tKey, "2");
+            assertThat(p1).isNotNull().isEqualTo(2.0);
+            assertThat(p2).isNotNull().isEqualTo(3.0);
+
+            Long zcard = redisTemplate.opsForZSet().size(tKey);
+            assertThat(zcard).isEqualTo(2L);
+
+            assertTtlRoughlyHours(tKey, ttlHours);
+        }
+    }
+
+    @Nested
+    @DisplayName("rebuildDailyAllRankings")
+    class RebuildAll {
+
+        @Test
+        @DisplayName("like/sales/pv 가중치로 all ZSET를 재구성하고 TTL이 설정된다")
+        void rebuildsAllWithWeights_whenRebuildDailyAllRankings() {
+            // given
+            LocalDate date = LocalDate.now();
+
+            redisTemplate.opsForZSet().add(likeKey(date), "7", 1.0);
+            redisTemplate.opsForZSet().add(salesKey(date), "7", 10.0);
+            redisTemplate.opsForZSet().add(pvKey(date), "7", 100.0);
+
+            double wLike  = rankingProperties.getWeight().getLike();
+            double wSales = rankingProperties.getWeight().getSales();
+            double wPv    = rankingProperties.getWeight().getPv();
+            double expected = 1.0 * wLike + 10.0 * wSales + 100.0 * wPv;
+
+            // when
+            productMetricService.rebuildAllRankings(date);
+
+            // then
+            Double score = redisTemplate.opsForZSet()
+                    .score(allKey(date), "7");
+            assertThat(score).isNotNull();
+            assertThat(score).isEqualTo(expected);
+
+            assertTtlRoughlyHours(allKey(date), rankingProperties.getTtlHours());
+        }
+    }
+
+}

--- a/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/EventType.java
+++ b/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/EventType.java
@@ -13,6 +13,12 @@ public enum EventType {
     // 제품 좋아요 변화 이벤트
     LIKE_CHANGED("LIKE_CHANGED"),
 
+    // 주문 이벤트
+    ORDER_COMPLETED("ORDER_COMPLETED"),
+
+    // 페이지 조회 이벤트
+    PAGE_VIEWED("PAGE_VIEWED"),
+
     // TRACE 도메인 이벤트
     TRACE_LIKE_CREATED("TRACE_LIKE_CREATED"),
     TRACE_LIKE_CANCELED("TRACE_LIKE_CANCELED"),

--- a/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/order/OrderOutEvent.java
+++ b/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/order/OrderOutEvent.java
@@ -1,0 +1,38 @@
+package com.loopers.common.kafka.event.order;
+
+import com.loopers.common.kafka.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class OrderOutEvent {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Order implements Event {
+        private String eventId;
+        private String userId;
+        private Long productId;
+        private Long orderId;
+        private String orderNumber;
+        private Long quantity;
+        private LocalDateTime eventTime;
+
+        public static Order of(String userId, Long productId, Long orderId, String orderNumber, Long quantity, LocalDateTime eventTime) {
+            return Order.builder()
+                    .eventId(java.util.UUID.randomUUID().toString())
+                    .userId(userId)
+                    .productId(productId)
+                    .orderId(orderId)
+                    .orderNumber(orderNumber)
+                    .quantity(quantity)
+                    .eventTime(eventTime)
+                    .build();
+        }
+
+    }
+}

--- a/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/pageview/PageViewOutEvent.java
+++ b/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/event/pageview/PageViewOutEvent.java
@@ -1,0 +1,29 @@
+package com.loopers.common.kafka.event.pageview;
+
+import com.loopers.common.kafka.event.Event;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class PageViewOutEvent {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Viewed implements Event {
+        private String eventId;
+        private Long productId;
+        private LocalDateTime eventTime;
+
+        public static Viewed of(Long productId, LocalDateTime eventTime) {
+            return Viewed.builder()
+                    .eventId(java.util.UUID.randomUUID().toString())
+                    .productId(productId)
+                    .eventTime(eventTime)
+                    .build();
+        }
+    }
+}

--- a/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/topic/Topics.java
+++ b/modules/common-kafka-event/src/main/java/com/loopers/common/kafka/topic/Topics.java
@@ -6,6 +6,10 @@ public class Topics {
 
     public static final String TRACE = "trace-event";
 
+    public static final String ORDER = "order-event";
+
+    public static final String PAGE_VIEW = "pageview-event";
+
     public static class Trace {
         public static final String LIKE_CREATED = "trace-like-created";
         public static final String LIKE_CANCELED = "trace-like-canceled";

--- a/modules/redis/src/main/resources/redis.yml
+++ b/modules/redis/src/main/resources/redis.yml
@@ -14,6 +14,19 @@ datasource:
       - host: ${REDIS_REPLICA_1_HOST}
         port: ${REDIS_REPLICA_1_PORT}
 
+ranking:
+  ttl-hours: 36
+  weight:
+    like: 0.2
+    sales: 0.7
+    pv: 0.1
+  carry-over:
+    enabled: true
+    cron: "0 0 0 * * *"
+    zone: "Asia/Seoul"
+    rate: 0.10
+    lock-ttl-seconds: 300
+
 ---
 spring.config.activate.on-profile: local, test
 
@@ -25,6 +38,19 @@ datasource:
     replicas:
       - host: localhost
         port: 6380
+
+ranking:
+  ttl-hours: 36
+  weight:
+    like: 0.2
+    sales: 0.7
+    pv: 0.1
+  carry-over:
+    enabled: true
+    cron: "0 0 0 * * *"
+    zone: "Asia/Seoul"
+    rate: 0.10
+    lock-ttl-seconds: 300
 
 ---
 spring.config.activate.on-profile: dev


### PR DESCRIPTION
## 📌 Summary
- commerce-collector에서 redis zset을 이용한 랭킹 데이터 적재 구현
- commerce-api에서 redis zset을 조회해 랭킹 페이지 및 상품 정보에 랭킹 포함

## 💬 Review Points
1) rdb의 product_metric의 용도
rdb의 product_metric 테이블의 용도가 궁금합니다. redis를 캐시가 아닌 랭킹 데이터 적재용으로 사용한다면 rdb를 사용하지 않아도 된다고 생각됐습니다. product_metric은 redis 데이터가 사라졌을때를 위한 원본 데이터 저장용으로 사용되는걸까요?

2) 좋아요 랭킹, 주문 랭킹, 조회수 랭킹을 모두 지원하면서 종합 랭킹도 지원해야할경우
ranking:like, ranking:sales, ranking:pageview 를 각각 업데이트하면서 ranking:all도 함께 업데이트 하는 방법을 사용한다면 배치나 스케쥴러를 이용해서 ranking:all을 따로 조합해주지 않아도 될것같았습니다.  이런 방법에서 문제가될게 어떤게 있을까요?

3) 랭킹 조회시, 추가 조건이 들어가야할 경우 redis를 그대로 사용할 수 있을까요?
만약 전체 랭킹 조회 후 검은색 맨투맨만 보고싶다면 redis에서 랭킹 데이터를 가져온 후 다시 애플리케이션에서 필터링해야하는걸까요?
아니면 redis가 아닌 다른 영속화 도구를 사용하는걸 검토해야할까요

## ✅ Checklist

### 📈 Ranking Consumer

- [O]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [O]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [O]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [O]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [O]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [O]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References
